### PR TITLE
Not run playbook until all the initial packages are installed

### DIFF
--- a/modules/1_prepare/outputs.tf
+++ b/modules/1_prepare/outputs.tf
@@ -24,6 +24,6 @@ output "bastion_ip" {
 }
 
 output "bastion_public_ip" {
-    depends_on = [null_resource.bastion_init]
+    depends_on = [null_resource.bastion_packages]
     value = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
 }


### PR DESCRIPTION
I have seen in CICD job that helpernode playbook run fails because it cannot find ansible package installed.
This is wait for the ansible run until the initial packages are installed on bastion.