### PR TITLE
Revert "Use bastion resource instead of data source for external IP"

### DIFF
--- a/modules/1_prepare/outputs.tf
+++ b/modules/1_prepare/outputs.tf
@@ -25,5 +25,5 @@ output "bastion_ip" {
 
 output "bastion_public_ip" {
     depends_on = [null_resource.bastion_packages]
-    value = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+    value = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
 }

--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -112,6 +112,13 @@ data "ibm_pi_instance_ip" "bastion_ip" {
     pi_cloud_instance_id    = var.service_instance_id
 }
 
+data "ibm_pi_instance_ip" "bastion_public_ip" {
+    depends_on              = [ibm_pi_instance.bastion]
+    pi_instance_name        = ibm_pi_instance.bastion.pi_instance_name
+    pi_network_name         = ibm_pi_network.public_network.pi_network_name
+    pi_cloud_instance_id    = var.service_instance_id
+}
+
 resource "null_resource" "bastion_init" {
     connection {
         type        = "ssh"
@@ -120,7 +127,7 @@ resource "null_resource" "bastion_init" {
         private_key = var.private_key
         agent       = var.ssh_agent
         timeout     = "15m"
-        bastion_host = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+        bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
     }
     provisioner "remote-exec" {
         inline = [
@@ -159,7 +166,7 @@ resource "null_resource" "setup_proxy_info" {
         private_key = var.private_key
         agent       = var.ssh_agent
         timeout     = "15m"
-        bastion_host = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+        bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
     }
     # Setup proxy
     provisioner "remote-exec" {
@@ -205,7 +212,7 @@ resource "null_resource" "bastion_register" {
         private_key = var.private_key
         agent       = var.ssh_agent
         timeout     = "15m"
-        bastion_host = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+        bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
     }
 
     provisioner "remote-exec" {
@@ -240,7 +247,7 @@ resource "null_resource" "bastion_packages" {
         private_key = var.private_key
         agent       = var.ssh_agent
         timeout     = "15m"
-        bastion_host = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+        bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
     }
 
     provisioner "remote-exec" {
@@ -283,7 +290,7 @@ resource "null_resource" "setup_nfs_disk" {
         private_key = var.private_key
         agent       = var.ssh_agent
         timeout     = "15m"
-        bastion_host = compact(ibm_pi_instance.bastion.addresses.*.external_ip)[0]
+        bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
     }
     provisioner "file" {
         content     = templatefile("${path.module}/templates/create_disk_link.sh", local.disk_config)


### PR DESCRIPTION
Reverts ocp-power-automation/ocp4-upi-powervs#54

Reverting this so that it can be linked to correct issue