### PR TITLE
prevent bash expansion in password var

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -206,7 +206,7 @@ mv /etc/yum.repos.d/* /etc/yum.repos.d.bak/
 # Give some more time to subscription-manager
 sudo subscription-manager config --server.server_timeout=600
 sudo subscription-manager clean
-sudo subscription-manager register --username=${var.rhel_subscription_username} --password=${var.rhel_subscription_password} --force
+sudo subscription-manager register --username='${var.rhel_subscription_username}' --password='${var.rhel_subscription_password}' --force
 sudo subscription-manager refresh
 sudo subscription-manager attach --auto
 EOF


### PR DESCRIPTION
Single quotes will keep any bash expansion from being done inside a string. 
If you have any special bash characters in your password, the rh
subscription fails in your bastion node and no services will be
available for your cluster.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>