### PR TITLE
Support non-multipath SCSI disks for nfs volume

### DIFF
--- a/modules/1_prepare/templates/create_disk_link.sh
+++ b/modules/1_prepare/templates/create_disk_link.sh
@@ -5,12 +5,22 @@ sudo rescan-scsi-bus.sh -a -m -r
 
 storage_device=""
 storage_disk_name=${disk_name}
-for device in $(ls -1 /dev/mapper/mpath*|egrep -v "[0-9]$"); do
+
+if [[ -z $(ls -l /dev/mapper/mpath*) ]];then
+    disk_path=/dev/sd*
+    echo "Disk path is /dev/sd*"
+else
+    disk_path=/dev/mapper/mpath*
+    echo "Disk path is /dev/mapper/mpath*"
+fi
+
+for device in $(ls -1 $disk_path|egrep -v "[0-9]$"); do
     if [[ ! -b $device"1" ]]; then
         # Convert disk size to GB
         device_size=$(lsblk -b -dn -o SIZE $device | awk '{print $1/1073741824}')
         if [[ -z $storage_device && $device_size == ${volume_size} ]]; then
             storage_device=$device
+            echo "Storage disk is $device"
             # This symbolic link is used in openshift config
             echo "ENV{DEVTYPE}==\"disk\", ENV{SUBSYSTEM}==\"block\", ENV{DEVPATH}==\"$(sudo udevadm info --root --name="$storage_device" | sudo grep DEVPATH | sudo cut -f2 -d'=')\" SYMLINK+=\"$storage_disk_name\"" | sudo tee /lib/udev/rules.d/10-custom-ocp.rules;
             sudo udevadm control --reload-rules;


### PR DESCRIPTION
Handle the case when bastion image does not have multipath installed and configured.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>