### PR TITLE
Set mtu on public network to 1450

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -146,6 +146,9 @@ resource "null_resource" "bastion_init" {
             "echo 'vm.max_map_count = 262144' | sudo tee --append /etc/sysctl.conf > /dev/null",
             # Set SMT to user specified value; Should not fail for invalid values.
             "sudo ppc64_cpu --smt=${var.rhel_smt} | true",
+            # Set mtu to 1450 for public interface.
+            "sudo ip link set dev $(ip r | grep ${ibm_pi_network.public_network.pi_cidr} | awk '{print $3}') mtu 1450",
+            "echo MTU=1450 | sudo tee -a /etc/sysconfig/network-scripts/ifcfg-$(ip r | grep ${ibm_pi_network.public_network.pi_cidr} | awk '{print $3}')"
         ]
     }
 }


### PR DESCRIPTION
Setting default mtu on bastion public interface to 1450.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>