### PR TITLE
fail if rhsm subscribe fails

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -197,19 +197,19 @@ resource "null_resource" "bastion_register" {
     }
 
     provisioner "remote-exec" {
-        inline = [<<EOF
-# FIX for existing stale repos
-echo "Moving all file from /etc/yum.repos.d/ to /etc/yum.repos.d.bak/"
-mkdir /etc/yum.repos.d.bak/
-mv /etc/yum.repos.d/* /etc/yum.repos.d.bak/
+        inline = [
+          "echo \"registring bastion with subscription manager...\"",
+          "set -e",
+          "# FIX for existing stale repos",
+          "mkdir /etc/yum.repos.d.bak || true",
+          "mv /etc/yum.repos.d/* /etc/yum.repos.d.bak || true",
 
-# Give some more time to subscription-manager
-sudo subscription-manager config --server.server_timeout=600
-sudo subscription-manager clean
-sudo subscription-manager register --username='${var.rhel_subscription_username}' --password='${var.rhel_subscription_password}' --force
-sudo subscription-manager refresh
-sudo subscription-manager attach --auto
-EOF
+          "# Give some more time to subscription-manager",
+          "sudo subscription-manager config --server.server_timeout=600",
+          "sudo subscription-manager clean",
+          "sudo subscription-manager register --username='${var.rhel_subscription_username}' --password='${var.rhel_subscription_password}' --force",
+          "sudo subscription-manager refresh",
+          "sudo subscription-manager attach --auto"
         ]
     }
     provisioner "remote-exec" {


### PR DESCRIPTION
If the user supplies incorrect credentials or something goes wrong with
the RH Subsciption registation, the install should fail immediately.
Without this, none of the required services for the bastion and cluster
will be configured.

This was not failing before due to limitations with terraform's inline
and heredoc useage. This format seems to fail fast.

The other changes are to ensure that if the script is re-run and
directories are already moved (the workaround mentioned in the tf code),
that this does not fail the inline script.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>