### PR TITLE
Use the latest ibm provider plugin v1.13.0 and use the community ignition plugin v2.1

### DIFF
--- a/docs/automation_host_prereqs.md
+++ b/docs/automation_host_prereqs.md
@@ -4,8 +4,6 @@
 - [Automation Host Prerequisites](#automation-host-prerequisites)
   - [Automation Host Setup](#automation-host-setup)
     - [Terraform](#terraform)
-    - [Additional Terraform Providers](#additional-terraform-providers)
-      - [Ignition provider v2.1.0](#ignition-provider-v210)
     - [PowerVS CLI](#powervs-cli)
     - [Git [*OPTIONAL*]](#git-optional)
 
@@ -16,32 +14,6 @@ Install the following packages on the automation host. Select the appropriate in
 ### Terraform
 
 **Terraform >= 0.13.0**: Please refer to the [link](https://learn.hashicorp.com/terraform/getting-started/install.html) for instructions on installing Terraform. For validating the version run `terraform version` command after install.
-
-### Additional Terraform Providers
-
-At present Terraform registry does not support below plugins. Third-party providers can be manually installed using [local filesystem as a mirror](https://www.terraform.io/docs/commands/cli-config.html#filesystem_mirror). This is in addition to the provider plugins that are downloaded by Terraform during `terraform init`.
-
-#### Ignition provider v2.1.0
-
-1. Download the zip archive from [community-terraform-provider releases page](https://github.com/community-terraform-providers/terraform-provider-ignition/releases/tag/v2.1.0) .
-
-2. Depending on your automation host platform, create the Terraform plugins directory on your local filesystem if it does not exist already.
-
-> Linux: ~/.local/share/terraform/plugins OR /usr/local/share/terraform/plugins, OR /usr/share/terraform/plugins.
-
-> Mac OSX: ~/Library/Application Support/io.terraform/plugins OR /Library/Application Support/io.terraform/plugins
-
-> Windows: %APPDATA%/HashiCorp/Terraform/plugins
-
-3. Under the path created in Step 2 please create the Igniton provider directory: `registry.terraform.io/terraform-providers/ignition/`
-4. Place the downloaded zip file in Step 1 to `registry.terraform.io/terraform-providers/ignition/`
-
-Example directory layout on Linux (x86_64)
-```
-$ ls ~/.local/share/terraform/plugins/registry.terraform.io/terraform-providers/ignition/
-terraform-provider-ignition_2.1.0_linux_amd64.zip
-$
-```
 
 ### PowerVS CLI
 

--- a/modules/1_prepare/versions.tf
+++ b/modules/1_prepare/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.11.2"
+      version = "~> 1.13.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.11.2"
+      version = "~> 1.13.0"
     }
     ignition = {
       source  = "terraform-providers/ignition"

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -25,8 +25,8 @@ terraform {
       version = "~> 1.13.0"
     }
     ignition = {
-      source  = "terraform-providers/ignition"
-      version = "~> 2.1"
+      source  = "community-terraform-providers/ignition"
+      version = "~> 2.1.0"
     }
   }
   required_version = "~> 0.13.0"

--- a/modules/5_install/versions.tf
+++ b/modules/5_install/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.11.2"
+      version = "~> 1.13.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/versions.tf
+++ b/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "ibm-cloud/ibm"
-      version = "1.11.2"
+      version = "~> 1.13.0"
     }
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
Use the latest ibm provider plugin v1.13.0
This has a couple of bug fixes related to network id ordering and handling error state.

Use the community ignition plugin v2.1
We no longer need to download the ignition plugin binary and is now part of terraform registry.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>
