### PR TITLE
Use hostnames instead of IP in inventory

### DIFF
--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -50,6 +50,7 @@ locals {
         cluster_domain  = local.cluster_domain
         cluster_id      = var.cluster_id
         bastion_ip      = var.bastion_vip != "" ? var.bastion_vip : var.bastion_ip[0]
+        bastion_name    = var.bastion_vip != "" ? "${var.cluster_id}-bastion" : "${var.cluster_id}-bastion-0"
         isHA            = var.bastion_vip != ""
         bastion_master_ip   = var.bastion_ip[0]
         bastion_backup_ip   = length(var.bastion_ip) > 1 ? slice(var.bastion_ip, 1, length(var.bastion_ip)) : []
@@ -93,10 +94,10 @@ locals {
     }
 
     install_inventory = {
-        bastion_ip      = var.bastion_ip
-        bootstrap_ip    = var.bootstrap_ip
-        master_ips      = var.master_ips
-        worker_ips      = var.worker_ips
+        bastion_hosts   = [for ix in range(length(var.bastion_ip)) : "${var.cluster_id}-bastion-${ix}"]
+        bootstrap_host  = "bootstrap"
+        master_hosts    = [for ix in range(length(var.master_ips)) : "master-${ix}"]
+        worker_hosts    = [for ix in range(length(var.worker_ips)) : "worker-${ix}"]
     }
 
     proxy = {

--- a/modules/5_install/templates/helpernode_vars.yaml
+++ b/modules/5_install/templates/helpernode_vars.yaml
@@ -1,7 +1,7 @@
 ---
 disk: vda
 helper:
-  name: "${cluster_id}-bastion"
+  name: "${bastion_name}"
   ipaddr: "${bastion_ip}"
 %{ if isHA }
 high_availability:

--- a/modules/5_install/templates/install_inventory
+++ b/modules/5_install/templates/install_inventory
@@ -1,17 +1,17 @@
 [bastion]
-%{ for ip in bastion_ip ~}
-${ip} ansible_connection=ssh ansible_user=root
+%{ for bastion in bastion_hosts ~}
+${bastion} ansible_connection=ssh ansible_user=root
 %{ endfor ~}
 
 [bootstrap]
-${bootstrap_ip} ansible_connection=ssh ansible_user=core
+${bootstrap_host} ansible_connection=ssh ansible_user=core
 
 [masters]
-%{ for master in master_ips ~}
+%{ for master in master_hosts ~}
 ${master} ansible_connection=ssh ansible_user=core
 %{ endfor ~}
 
 [workers]
-%{ for worker in worker_ips ~}
+%{ for worker in worker_hosts ~}
 ${worker} ansible_connection=ssh ansible_user=core
 %{ endfor ~}


### PR DESCRIPTION
Using hostnames in the install playbook inventory will help us debugging issues related to hosts by looking at the logs directly.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>