### PR TITLE
Remove stale repo fix and improve subscription check

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -184,7 +184,7 @@ EOF
 }
 
 resource "null_resource" "bastion_register" {
-    count       = var.rhel_subscription_username != "" ? local.bastion_count : 0
+    count       = var.rhel_subscription_username == "" || var.rhel_subscription_username  == "<subscription-id>" ? 0 : local.bastion_count
     depends_on  = [null_resource.bastion_init, null_resource.setup_proxy_info]
     triggers = {
         external_ip     = data.ibm_pi_instance_ip.bastion_public_ip[count.index].external_ip
@@ -204,10 +204,6 @@ resource "null_resource" "bastion_register" {
 
     provisioner "remote-exec" {
         inline = [<<EOF
-# FIX for existing stale repos
-echo "Moving all file from /etc/yum.repos.d/ to /etc/yum.repos.d.bak/"
-mkdir /etc/yum.repos.d.bak/
-mv /etc/yum.repos.d/* /etc/yum.repos.d.bak/
 
 # Give some more time to subscription-manager
 sudo subscription-manager config --server.server_timeout=600


### PR DESCRIPTION
1. Removed stale repo fix as this stale repos is on the user creating the image. Since most of the resources have fresh image we should not have this.
2. For centos users `rhel_subscription_username  == "<subscription-id>"` being set in var.tfvars would have issues. We should not try the subscription if the value is unchanged.
Signed-off-by: Yussuf Shaikh <yussuf.shaikh@ibm.com>