### PR TITLE
Use external VIP from the public network port

### DIFF
--- a/modules/1_prepare/outputs.tf
+++ b/modules/1_prepare/outputs.tf
@@ -49,3 +49,8 @@ output "bastion_internal_vip" {
     depends_on  = [null_resource.bastion_init]
     value       = local.bastion_count > 1 ? ibm_pi_network_port.bastion_internal_vip[0].pi_network_port_ipaddress : ""
 }
+
+output "bastion_external_vip" {
+    depends_on  = [null_resource.bastion_init]
+    value       = local.bastion_count > 1 ? ibm_pi_network_port.bastion_internal_vip[0].public_ip : ""
+}

--- a/modules/1_prepare/versions.tf
+++ b/modules/1_prepare/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "~> 1.13.0"
+      version = "~> 1.15.0"
     }
     null = {
       source = "hashicorp/null"

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "~> 1.13.0"
+      version = "~> 1.15.0"
     }
     ignition = {
       source  = "terraform-providers/ignition"

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -19,24 +19,15 @@
 ################################################################
 
 locals {
-    # FIXME: Remove below logic when API for reading external IP from public network_port is available.
-    # Since Power Virtual Server API or Terraform module does not allow to read the external IP from network port...
-    # Provide a workaround to get the external VIP address
-    # 1. Split public vip to a list eg: ["192","XXX","XXX","2"] and get the last octect eg: "2".
-    # 2. Split the 1st bastion external ip and slice it to length 3 eg: ["158","XXX","XXX"]
-    # 3. Concat the last octect to form the external vip and convert it to a string eg: "158.XXX.XXX.2"
-    pub_vip_last_octet      = var.bastion_internal_vip == "" ? "" : split(".", var.bastion_internal_vip)[3]
-    ext_ip_prefix           = var.bastion_internal_vip == "" ? [] : slice(split(".", var.bastion_public_ip[0]),0,3)
-    bastion_external_vip    = var.bastion_internal_vip == "" ? "" : "${join(".",local.ext_ip_prefix)}.${local.pub_vip_last_octet}"
 
     public_vrrp = {
-        virtual_router_id   = local.pub_vip_last_octet
+        virtual_router_id   = var.bastion_internal_vip == "" ? "" : split(".", var.bastion_internal_vip)[3]
         virtual_ipaddress   = var.bastion_internal_vip
         password            = uuid()
     }
 
     wildcard_dns    = ["nip.io", "xip.io", "sslip.io"]
-    cluster_domain  = contains(local.wildcard_dns, var.cluster_domain) ? "${local.bastion_external_vip != "" ? local.bastion_external_vip : var.bastion_public_ip[0]}.${var.cluster_domain}" : var.cluster_domain
+    cluster_domain  = contains(local.wildcard_dns, var.cluster_domain) ? "${var.bastion_external_vip != "" ? var.bastion_external_vip : var.bastion_public_ip[0]}.${var.cluster_domain}" : var.cluster_domain
 
     local_registry  = {
         enable_local_registry   = var.enable_local_registry

--- a/modules/5_install/outputs.tf
+++ b/modules/5_install/outputs.tf
@@ -35,5 +35,5 @@ output "web_console_url" {
 
 output "bastion_external_vip" {
     depends_on = [null_resource.configure_public_vip]
-    value = local.bastion_external_vip
+    value = var.bastion_external_vip
 }

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -39,6 +39,7 @@ variable "bastion_count" {}
 variable "bastion_vip" {}
 variable "bastion_ip" {}
 variable "bastion_internal_vip" {}
+variable "bastion_external_vip" {}
 variable "bastion_public_ip" {}
 variable "rhel_username" {}
 variable "private_key" {}

--- a/modules/5_install/versions.tf
+++ b/modules/5_install/versions.tf
@@ -20,10 +20,6 @@
 
 terraform {
   required_providers {
-    ibm = {
-      source = "IBM-Cloud/ibm"
-      version = "~> 1.13.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = "~> 2.1"

--- a/ocp.tf
+++ b/ocp.tf
@@ -81,6 +81,7 @@ module "install" {
     private_key                     = local.private_key
     ssh_agent                       = var.ssh_agent
     bastion_internal_vip            = module.prepare.bastion_internal_vip
+    bastion_external_vip            = module.prepare.bastion_external_vip
     bastion_public_ip               = module.prepare.bastion_public_ip
     bootstrap_ip                    = module.nodes.bootstrap_ip
     master_ips                      = module.nodes.master_ips

--- a/versions.tf
+++ b/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "~> 1.13.0"
+      version = "~> 1.15.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION

1. Update IBM provider to the latest version
2. Use external VIP from network port

Fixes #45

Signed-off-by: Yussuf Shaikh yussuf.shaikh@ibm.com