### PR TITLE
checks included in Terraform install code for changes in the worker node

### DIFF
--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -127,6 +127,9 @@ locals {
 }
 
 resource "null_resource" "config" {
+    triggers = {
+        worker_count = length(var.worker_ips)
+    }
     connection {
         type        = "ssh"
         user        = var.rhel_username
@@ -197,6 +200,9 @@ resource "null_resource" "configure_public_vip" {
 
 resource "null_resource" "install" {
     depends_on = [null_resource.config, null_resource.configure_public_vip]
+    triggers = {
+        worker_count = length(var.worker_ips)
+    }
 
     connection {
         type        = "ssh"


### PR DESCRIPTION
The trigger is included in 5_install/install.tf. Number of worker nodes are tracked through the  number of assigned worker node ips. The triggers are put in both config and install resource.