### PR TITLE
Add variable to set default CNI network provider

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -290,3 +290,9 @@ The following variables are specific to enable the connectivity between OCP node
 ibm_cloud_dl_endpoint_net_cidr = ""
 ibm_cloud_http_proxy = ""
 ```
+
+This variable is used to set the default Container Network Interface (CNI) network provider such as OpenShiftSDN or OVNKubernetes
+
+```
+cni_network_provider       = "OpenshiftSDN"
+```

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -117,6 +117,7 @@ locals {
         squid_source_range      = var.cidr
         proxy_url               = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
         no_proxy                = var.cidr
+        cni_network_provider    = var.cni_network_provider
     }
 
     powervs_config_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -41,3 +41,5 @@ dhcp_shared_network: true
 %{ if bastion_vip != "" }
 bastion_vip: "${bastion_vip}"
 %{ endif ~}
+
+cni_network_provider: ${cni_network_provider}

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -87,3 +87,5 @@ variable "proxy" {}
 
 variable "ibm_cloud_dl_endpoint_net_cidr" {}
 variable "ibm_cloud_http_proxy" {}
+
+variable "cni_network_provider" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -122,4 +122,5 @@ module "install" {
     upgrade_delay_time              = var.upgrade_delay_time
     ibm_cloud_dl_endpoint_net_cidr  = var.ibm_cloud_dl_endpoint_net_cidr
     ibm_cloud_http_proxy            = var.ibm_cloud_http_proxy
+    cni_network_provider            = var.cni_network_provider
 }

--- a/var.tfvars
+++ b/var.tfvars
@@ -85,3 +85,5 @@ cluster_id                  = ""
 
 #ibm_cloud_dl_endpoint_net_cidr = ""  #Set this to IBM Cloud DirectLink endpoint network cidr eg. 10.0.0.0/8
 #ibm_cloud_http_proxy = ""            #Set this to IBM Cloud http/squid proxy eg. http://10.166.13.64:3128
+
+#cni_network_provider       = "OpenshiftSDN"

--- a/variables.tf
+++ b/variables.tf
@@ -251,7 +251,7 @@ variable "install_playbook_tag" {
     type        = string
     description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
     # Checkout level for https://github.com/ocp-power-automation/ocp4-playbooks which is used for running ocp4 installations steps
-    default     = "fc74d7ec06b2dd47c134c50b66b478abde32e295"
+    default     = "592e51671ff2762718955fb2a0541a5b19c862e9"
 }
 
 variable "ansible_extra_options" {
@@ -453,6 +453,11 @@ variable "upgrade_delay_time" {
     type        = string
     description = "Number of seconds to wait before re-checking the upgrade status once the playbook execution resumes."
     default     = "600"
+}
+
+variable "cni_network_provider" {
+    description = "Set the default Container Network Interface (CNI) network provider"
+    default     = "OpenshiftSDN"
 }
 
 ################################################################


### PR DESCRIPTION
The default cni network provider can be set for deployment via the networkType variable in the install-config. The values can be OpenshiftSDN or OVNKubernetes.

Signed-off-by: Pravin Dsilva <pravin.d-silva@ibm.com>