### PR TITLE
Add zone info to instance name

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -183,6 +183,8 @@ Edit it as per your requirements.
 cluster_domain              = "ibm.com"
 cluster_id_prefix           = "test-ocp"
 cluster_id                  = ""
+
+use_zone_info_for_names  = true
 ```
 Set the `cluster_domain` to `nip.io`, `xip.io` or `sslip.io` if you prefer using online wildcard domains.
 Default is `ibm.com`.
@@ -191,8 +193,9 @@ Default value is `test-ocp`
 If `cluster_id_prefix` is not set, the `cluster_id` will be used only without prefix.
 
 A random value will be used for `cluster_id` if not set.
-The total length of `cluster_id_prefix`.`cluster_id` should not exceed 14 characters.
+The total length of `cluster_id_prefix`.`cluster_id` should not exceed 32 characters.
 
+The `use_zone_info_for_names` is a flag to indicate whether to use `cluster_id`-`ibmcloud_zone` or only `cluster_id` as name prefix for resource naming on PowerVS. The default value is set to `true` to use zone info in names, and the total length of `cluster_id_prefix`-`cluster_id`-`ibmcloud_zone` should not exceed 32 characters.
 
 ### Using IBM Cloud Services
 

--- a/modules/1_prepare/variables.tf
+++ b/modules/1_prepare/variables.tf
@@ -23,11 +23,20 @@ variable "cluster_id" {
   type = string
 
   validation {
-    condition     = length(var.cluster_id) <= 14
-    error_message = "Length cannot exceed 14 characters when combined with cluster_id_prefix."
+    condition     = length(var.cluster_id) <= 32
+    error_message = "Length cannot exceed 32 characters when combined with cluster_id_prefix."
   }
 }
 variable "bastion" {}
+
+variable "name_prefix" {
+  type = string
+
+  validation {
+    condition     = length(var.name_prefix) <= 32
+    error_message = "Length cannot exceed 32 characters for name_prefix."
+  }
+}
 
 variable "service_instance_id" {}
 variable "rhel_image_name" {}

--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -53,7 +53,7 @@ resource "ibm_pi_instance" "bootstrap" {
 
   pi_memory            = var.bootstrap["memory"]
   pi_processors        = var.bootstrap["processors"]
-  pi_instance_name     = "${var.cluster_id}-bootstrap"
+  pi_instance_name     = "${var.name_prefix}-bootstrap"
   pi_proc_type         = var.processor_type
   pi_image_id          = data.ibm_pi_image.rhcos.id
   pi_sys_type          = var.system_type
@@ -64,7 +64,7 @@ resource "ibm_pi_instance" "bootstrap" {
   pi_user_data = base64encode(replace(data.ignition_config.bootstrap.rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}"))
 
   # Not needed by RHCOS but required by resource
-  pi_key_pair_name = "${var.cluster_id}-keypair"
+  pi_key_pair_name = "${var.name_prefix}-keypair"
   pi_health_status = "WARNING"
 }
 
@@ -94,7 +94,7 @@ resource "ibm_pi_instance" "master" {
 
   pi_memory            = var.master["memory"]
   pi_processors        = var.master["processors"]
-  pi_instance_name     = "${var.cluster_id}-master-${count.index}"
+  pi_instance_name     = "${var.name_prefix}-master-${count.index}"
   pi_proc_type         = var.processor_type
   pi_image_id          = data.ibm_pi_image.rhcos.id
   pi_sys_type          = var.system_type
@@ -106,7 +106,7 @@ resource "ibm_pi_instance" "master" {
   pi_user_data = base64encode(replace(data.ignition_config.master[count.index].rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}"))
 
   # Not needed by RHCOS but required by resource
-  pi_key_pair_name = "${var.cluster_id}-keypair"
+  pi_key_pair_name = "${var.name_prefix}-keypair"
   pi_health_status = "WARNING"
 }
 
@@ -114,7 +114,7 @@ resource "ibm_pi_volume" "master" {
   count = var.master_volume_size == "" ? 0 : var.master["count"]
 
   pi_volume_size       = var.master_volume_size
-  pi_volume_name       = "${var.cluster_id}-master-${count.index}-volume"
+  pi_volume_name       = "${var.name_prefix}-master-${count.index}-volume"
   pi_volume_type       = data.ibm_pi_image.rhcos.storage_type
   pi_volume_shareable  = var.volume_shareable
   pi_cloud_instance_id = var.service_instance_id
@@ -148,7 +148,7 @@ resource "ibm_pi_instance" "worker" {
 
   pi_memory            = var.worker["memory"]
   pi_processors        = var.worker["processors"]
-  pi_instance_name     = "${var.cluster_id}-worker-${count.index}"
+  pi_instance_name     = "${var.name_prefix}-worker-${count.index}"
   pi_proc_type         = var.processor_type
   pi_image_id          = data.ibm_pi_image.rhcos.id
   pi_sys_type          = var.system_type
@@ -160,7 +160,7 @@ resource "ibm_pi_instance" "worker" {
   pi_user_data = base64encode(replace(data.ignition_config.worker[count.index].rendered, "\"timeouts\":{}", "\"timeouts\":{\"httpTotal\":500}"))
 
   # Not needed by RHCOS but required by resource
-  pi_key_pair_name = "${var.cluster_id}-keypair"
+  pi_key_pair_name = "${var.name_prefix}-keypair"
   pi_health_status = "WARNING"
 }
 
@@ -198,7 +198,7 @@ resource "ibm_pi_volume" "worker" {
   count = var.worker_volume_size == "" ? 0 : var.worker["count"]
 
   pi_volume_size       = var.worker_volume_size
-  pi_volume_name       = "${var.cluster_id}-worker-${count.index}-volume"
+  pi_volume_name       = "${var.name_prefix}-worker-${count.index}-volume"
   pi_volume_type       = data.ibm_pi_image.rhcos.storage_type
   pi_volume_shareable  = var.volume_shareable
   pi_cloud_instance_id = var.service_instance_id

--- a/modules/4_nodes/variables.tf
+++ b/modules/4_nodes/variables.tf
@@ -29,6 +29,7 @@ variable "rhcos_image_name" {}
 variable "bastion_ip" {}
 variable "cluster_domain" {}
 variable "cluster_id" {}
+variable "name_prefix" {}
 
 variable "bootstrap" {}
 variable "master" {}

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -41,7 +41,7 @@ locals {
     cluster_domain        = local.cluster_domain
     cluster_id            = var.cluster_id
     bastion_ip            = var.bastion_vip != "" ? var.bastion_vip : var.bastion_ip[0]
-    bastion_name          = var.bastion_vip != "" ? "${var.cluster_id}-bastion" : "${var.cluster_id}-bastion-0"
+    bastion_name          = var.bastion_vip != "" ? "${var.name_prefix}-bastion" : "${var.name_prefix}-bastion-0"
     isHA                  = var.bastion_vip != ""
     bastion_master_ip     = var.bastion_ip[0]
     bastion_backup_ip     = length(var.bastion_ip) > 1 ? slice(var.bastion_ip, 1, length(var.bastion_ip)) : []
@@ -84,7 +84,7 @@ locals {
   }
 
   install_inventory = {
-    bastion_hosts  = [for ix in range(length(var.bastion_ip)) : "${var.cluster_id}-bastion-${ix}"]
+    bastion_hosts  = [for ix in range(length(var.bastion_ip)) : "${var.name_prefix}-bastion-${ix}"]
     bootstrap_host = var.bootstrap_ip == "" ? "" : "bootstrap"
     master_hosts   = [for ix in range(length(var.master_ips)) : "master-${ix}"]
     worker_hosts   = [for ix in range(length(var.worker_ips)) : "worker-${ix}"]

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -30,6 +30,7 @@ variable "dns_forwarders" {
 }
 
 variable service_instance_id {}
+variable "name_prefix" {}
 
 variable "gateway_ip" {}
 variable "cidr" {}

--- a/modules/7_ibmcloud/dns.tf
+++ b/modules/7_ibmcloud/dns.tf
@@ -30,7 +30,7 @@ resource "ibm_dns_record" "bastion" {
   count              = var.bastion_count
   data               = var.bastion_ip[count.index]
   domain_id          = data.ibm_dns_domain.domain.id
-  host               = "${var.cluster_id}-bastion-${count.index}.${var.cluster_id}"
+  host               = "${var.name_prefix}-bastion-${count.index}.${var.cluster_id}"
   responsible_person = "root.${var.cluster_domain}."
   ttl                = 900
   type               = "a"

--- a/modules/7_ibmcloud/load_balancer.tf
+++ b/modules/7_ibmcloud/load_balancer.tf
@@ -26,7 +26,7 @@ locals {
 }
 
 resource "ibm_is_lb" "load_balancer" {
-  name            = "${var.cluster_id}-loadbalancer"
+  name            = "${var.name_prefix}-loadbalancer"
   subnets         = [var.vpc_subnet_id]
   security_groups = [ibm_is_security_group.ocp_security_group.id]
 }

--- a/modules/7_ibmcloud/security_group.tf
+++ b/modules/7_ibmcloud/security_group.tf
@@ -26,7 +26,7 @@ data "ibm_is_vpc" "vpc" {
 }
 
 resource "ibm_is_security_group" "ocp_security_group" {
-  name = "${var.cluster_id}-ocp-sec-group"
+  name = "${var.name_prefix}-ocp-sec-group"
   vpc  = data.ibm_is_vpc.vpc.id
 }
 

--- a/modules/7_ibmcloud/variables.tf
+++ b/modules/7_ibmcloud/variables.tf
@@ -24,6 +24,7 @@ variable "cluster_domain" {
 variable "cluster_id" {
   default = "test-ocp"
 }
+variable "name_prefix" {}
 
 variable "vpc_name" {}
 variable "vpc_subnet_id" {}

--- a/var.tfvars
+++ b/var.tfvars
@@ -42,6 +42,7 @@ cluster_domain    = "ibm.com"  #Set domain to nip.io or xip.io if you prefer usi
 cluster_id_prefix = "test-ocp" # Set it to empty if just want to use cluster_id without prefix
 cluster_id        = ""         # It will use random generated id with cluster_id_prefix if this is not set
 
+use_zone_info_for_names = true # If set it to false, the zone info would not be used in resource names on PowerVS.
 
 ### Using IBM Cloud Services
 #use_ibm_cloud_services    = true

--- a/variables.tf
+++ b/variables.tf
@@ -368,7 +368,7 @@ variable "setup_squid_proxy" {
 }
 
 # Applicable only when `setup_squid_proxy = false`
-variable proxy {
+variable "proxy" {
   type        = object({})
   description = "External Proxy server details in a map"
   default     = {}
@@ -447,6 +447,12 @@ variable "cluster_id" {
     condition     = length(var.cluster_id) <= 14
     error_message = "The cluster_id value shouldn't be greater than 14 characters."
   }
+}
+
+variable "use_zone_info_for_names" {
+  type        = bool
+  default     = true
+  description = "Add zone info to instance name or not"
 }
 
 variable "storage_type" {


### PR DESCRIPTION
Fixed #242 

Add a flag `use_zone_info_for_instance`, the default is set to true.

Signed-off-by: CS Zhang <zhangcho@us.ibm.com>