### PR TITLE
WIP: Add facility to attach multiple volumes to worker nodes

### DIFF
--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -195,7 +195,7 @@ EOF
 }
 
 resource "ibm_pi_volume" "worker" {
-  count = var.worker_volume_size == "" ? 0 : var.worker["count"]
+  count = var.worker_volume_size == "" ? 0 : var.worker["count"] * var.worker_volume_count
 
   pi_volume_size       = var.worker_volume_size
   pi_volume_name       = "${var.name_prefix}-worker-${count.index}-volume"

--- a/modules/4_nodes/variables.tf
+++ b/modules/4_nodes/variables.tf
@@ -37,6 +37,7 @@ variable "worker" {}
 
 variable "master_volume_size" {}
 variable "worker_volume_size" {}
+variable "worker_volume_count" {}
 variable "volume_shareable" {}
 
 variable "bastion_public_ip" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -73,6 +73,7 @@ module "nodes" {
   worker              = var.worker
   master_volume_size  = var.master_volume_size
   worker_volume_size  = var.worker_volume_size
+  worker_volume_count = var.worker_volume_count
   volume_shareable    = var.volume_shareable
   bastion_public_ip   = module.prepare.bastion_public_ip
   rhel_username       = var.rhel_username

--- a/variables.tf
+++ b/variables.tf
@@ -488,6 +488,12 @@ variable "worker_volume_size" {
   default     = "" # Value in GB
 }
 
+variable "worker_volume_count" {
+  type        = string
+  description = "Number of volumes attached to the worker nodes."
+  default     = "1"
+}
+
 variable "upgrade_version" {
   type        = string
   description = "OCP upgrade version"


### PR DESCRIPTION
This commit includes code to attach more than 1 data volume
to the worker node.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>