### PR TITLE
Add upgrade_image option

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -348,10 +348,13 @@ volume_shareable            = false
 
 The following variables are specific to upgrading an existing installation.
 ```
+upgrade_image      = ""  #(e.g. `"quay.io/openshift-release-dev/ocp-release-nightly@sha256:xxxxx"`)
 upgrade_version    = ""
 upgrade_pause_time = "70"
 upgrade_delay_time = "600"
 ```
+One of the two varaibles `upgrade_image` or `upgrade_version` is required for upgrading the cluster.
+`upgrade_image` having higher precedence than `upgrade_version`.
 
 The following variables are specific to enable the connectivity between OCP nodes in PowerVS and IBM Cloud infrastructure over DirectLink.
 ```

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -154,6 +154,7 @@ locals {
   }
 
   upgrade_vars = {
+    upgrade_image   = var.upgrade_image
     upgrade_version = var.upgrade_version
     pause_time      = var.upgrade_pause_time
     delay_time      = var.upgrade_delay_time
@@ -400,9 +401,10 @@ resource "null_resource" "powervs_config" {
 
 resource "null_resource" "upgrade" {
   depends_on = [null_resource.install, null_resource.powervs_config]
-  count      = var.upgrade_version != "" ? 1 : 0
+  count      = var.upgrade_version != "" || var.upgrade_image != "" ? 1 : 0
   triggers = {
     upgrade_version = var.upgrade_version
+    upgrade_image   = var.upgrade_image
   }
 
   connection {

--- a/modules/5_install/templates/upgrade_vars.yaml
+++ b/modules/5_install/templates/upgrade_vars.yaml
@@ -1,4 +1,5 @@
 ---
+upgrade_image: "${upgrade_image}"
 upgrade_version: "${upgrade_version}"
 pause_time: ${pause_time}
 delay_time: ${delay_time}

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -90,6 +90,7 @@ variable "rhcos_kernel_options" {}
 variable "chrony_config" { default = true }
 variable "chrony_config_servers" {}
 
+variable "upgrade_image" {}
 variable "upgrade_version" {}
 variable "upgrade_pause_time" {}
 variable "upgrade_delay_time" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -163,6 +163,7 @@ module "install" {
   rhcos_kernel_options           = var.rhcos_kernel_options
   chrony_config                  = var.chrony_config
   chrony_config_servers          = var.chrony_config_servers
+  upgrade_image                  = var.upgrade_image
   upgrade_version                = var.upgrade_version
   upgrade_pause_time             = var.upgrade_pause_time
   upgrade_delay_time             = var.upgrade_delay_time

--- a/var.tfvars
+++ b/var.tfvars
@@ -99,6 +99,7 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 #volume_size                = "300"    #Value in GB
 #volume_shareable           = false
 
+#upgrade_image              = "" #quay.io/openshift-release-dev/ocp-release@sha256:xyz.."
 #upgrade_version            = ""
 #upgrade_pause_time         = "70"
 #upgrade_delay_time         = "600"

--- a/variables.tf
+++ b/variables.tf
@@ -498,6 +498,12 @@ variable "volume_shareable" {
   default     = false
 }
 
+variable "upgrade_image" {
+  type        = string
+  description = "OCP upgrade image e.g. quay.io/openshift-release-dev/ocp-release-nightly@sha256:xxxxx"
+  default     = ""
+}
+
 variable "upgrade_version" {
   type        = string
   description = "OCP upgrade version"


### PR DESCRIPTION
For upgrading the cluster with the specific build, added `upgrade_image` variable.
Signed-off-by: Varad Ahirwadkar <varad.ahirwadkar@ibm.com>