### PR TITLE
Update install.tf to use shallow clone

### DIFF
--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -8,7 +8,7 @@
 #
 # Licensed Materials - Property of IBM
 #
-# ©Copyright IBM Corp. 2020
+# ©Copyright IBM Corp. 2020, 2022
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -180,7 +180,7 @@ resource "null_resource" "config" {
       "mkdir -p .openshift",
       "rm -rf ocp4-helpernode",
       "echo 'Cloning into ocp4-helpernode...'",
-      "git clone ${var.helpernode_repo} --quiet",
+      "git clone ${var.helpernode_repo} --quiet --depth 1",
       "cd ocp4-helpernode && git checkout ${var.helpernode_tag}"
     ]
   }
@@ -352,7 +352,7 @@ resource "null_resource" "install" {
     inline = [
       "rm -rf ocp4-playbooks",
       "echo 'Cloning into ocp4-playbooks...'",
-      "git clone ${var.install_playbook_repo} --quiet",
+      "git clone ${var.install_playbook_repo} --quiet --depth 1",
       "cd ocp4-playbooks && git checkout ${var.install_playbook_tag}"
     ]
   }


### PR DESCRIPTION
git clone uses --quiet, yet it's deep clone.  Adding `--depth 1` improves performance a few hundred milliseconds difference in the time spent cloning, and long term it can avoid a superlinear increase in processing as the commit history grows.  Switching to a shallow clone improves performance about 100K difference in downloading ocp4-playbooks and 13M difference in downloading ocp4-helpernode.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>