### PR TITLE
Update prepare.tf

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -336,7 +336,7 @@ resource "null_resource" "bastion_packages" {
   }
   provisioner "remote-exec" {
     inline = [
-      "sudo yum install -y ansible-2.9.*"
+      "sudo yum install -y ansible"
     ]
   }
 }


### PR DESCRIPTION
Remove the dependency on Ansible 2.9 and let the OS install its version. This Ansible 2.9 is breaking all installations where CentOS Stream is used as bastion.