### PR TITLE
added an output attribute name_prefix

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -22,6 +22,10 @@ output "cluster_id" {
   value = local.cluster_id
 }
 
+output "name_prefix" {
+  value = local.name_prefix
+}
+
 output "bastion_private_vip" {
   value = module.prepare.bastion_vip == "" ? null : module.prepare.bastion_vip
 }


### PR DESCRIPTION
This variable will help to figure out the node names based on `use_zone_info_for_names` variable.

Signed-off-by: Yussuf Shaikh <yussuf.shaikh1@ibm.com>