### PR TITLE
Update default CNI to OVNKubernetes

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -375,7 +375,7 @@ ibm_cloud_http_proxy = ""
 This variable is used to set the default Container Network Interface (CNI) network provider such as OpenShiftSDN or OVNKubernetes
 
 ```
-cni_network_provider       = "OpenshiftSDN"
+cni_network_provider       = "OVNKubernetes"
 ```
 
 This variable is used to enable SNAT for OCP nodes. When using SNAT, the OCP nodes will be able to access public internet without using a proxy

--- a/var.tfvars
+++ b/var.tfvars
@@ -108,7 +108,7 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 #ibm_cloud_dl_endpoint_net_cidr = ""  #Set this to IBM Cloud DirectLink endpoint network cidr eg. 10.0.0.0/8
 #ibm_cloud_http_proxy = ""            #Set this to IBM Cloud http/squid proxy eg. http://10.166.13.64:3128
 
-#cni_network_provider       = "OpenshiftSDN"
+#cni_network_provider       = "OVNKubernetes"
 
 #setup_snat                 = true
 

--- a/variables.tf
+++ b/variables.tf
@@ -530,7 +530,7 @@ variable "upgrade_delay_time" {
 
 variable "cni_network_provider" {
   description = "Set the default Container Network Interface (CNI) network provider"
-  default     = "OpenshiftSDN"
+  default     = "OVNKubernetes"
 }
 
 variable "fips_compliant" {


### PR DESCRIPTION
With OCP 4.12, the default network type is OVNKubernetes
Reference: https://github.com/openshift/installer/pull/6014

Signed-off-by: Pravin D'silva <pravin.dsilva@ibm.com>