### PR TITLE
Add support for LUKS encryption for OCP4

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -392,3 +392,19 @@ csi_driver_type            = "stable"
 csi_driver_version         = "v0.1.1"
 ```
 **IMPORTANT**: This is an **experimental** feature and not yet ready for production.
+
+These set of variables are specific for LUKS encryption configuration and installation.
+
+```
+luks_compliant              = false # Set it true if you prefer to use FIPS enable in ocp deployment
+luks_config                 = [ { thumbprint = "", url = "" }, { thumbprint = "", url = "" }, { thumbprint = "", url = "" } ]
+luks_filesystem_device      = "/dev/mapper/root"  #Set this value for file system device
+luks_format                 = "xfs"  #Set value of format for filesystem 
+luks_wipeFileSystem         = true  #Set value of wipeFileSystem 
+luks_device                 = "/dev/disk/by-partlabel/root"  #Set value of luks device 
+luks_label                  = "luks-root"  #Set value of tang label 
+luks_options                = ["--cipher", "aes-cbc-essiv:sha256"]  #Set List of luks options for the luks encryption 
+luks_wipeVolume             = true  #Set value of wipeVolume 
+luks_name                   = root  #Set value of luks name 
+
+```

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -131,7 +131,17 @@ locals {
     cni_network_provider     = var.cni_network_provider
     # Set CNI network MTU to MTU - 100 for OVNKubernetes and MTU - 50 for OpenShiftSDN(default).
     # Add new conditions here when we have more network providers
-    cni_network_mtu = var.cni_network_provider == "OVNKubernetes" ? var.private_network_mtu - 100 : var.private_network_mtu - 50
+    cni_network_mtu        = var.cni_network_provider == "OVNKubernetes" ? var.private_network_mtu - 100 : var.private_network_mtu - 50
+    luks_compliant         = var.luks_compliant
+    luks_config            = var.luks_config
+    luks_filesystem_device = var.luks_filesystem_device
+    luks_format            = var.luks_format
+    luks_wipeFileSystem    = var.luks_wipeFileSystem
+    luks_device            = var.luks_device
+    luks_label             = var.luks_label
+    luks_options           = var.luks_options
+    luks_wipeVolume        = var.luks_wipeVolume
+    luks_name              = var.luks_name
   }
 
   powervs_config_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -52,3 +52,26 @@ bastion_vip: "${bastion_vip}"
 
 cni_network_provider: ${cni_network_provider}
 cni_network_mtu: ${cni_network_mtu}
+
+%{ if luks_compliant && length(luks_config) > 0 ~}
+luks:
+ enabled: true
+ config:
+%{ for item in luks_config ~}
+    - thumbprint: ${item.thumbprint}
+      url: ${item.url}
+%{ endfor ~}
+ filesystem_device: ${luks_filesystem_device}
+ format: ${luks_format}
+ wipeFileSystem: "${luks_wipeFileSystem}"
+ device: ${luks_device}
+ label: ${luks_label}
+%{ if length(luks_options) > 0 ~}
+ options:
+%{ for item in luks_options ~}
+    - ${item}
+%{ endfor ~}
+%{ endif ~}
+ wipeVolume: "${luks_wipeVolume}"
+ name: ${luks_name}
+%{ endif ~}

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -114,3 +114,14 @@ variable "ibmcloud_api_key" {}
 variable "csi_driver_install" {}
 variable "csi_driver_type" {}
 variable "csi_driver_version" {}
+
+variable "luks_compliant" { default = false }
+variable "luks_config" {}
+variable "luks_filesystem_device" {}
+variable "luks_format" {}
+variable "luks_wipeFileSystem" {}
+variable "luks_device" {}
+variable "luks_label" {}
+variable "luks_options" {}
+variable "luks_wipeVolume" {}
+variable "luks_name" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -178,6 +178,16 @@ module "install" {
   csi_driver_type                = var.csi_driver_type
   csi_driver_version             = var.csi_driver_version
   vpc_cidr                       = var.use_ibm_cloud_services ? data.ibm_is_subnet.vpc_subnet[0].ipv4_cidr_block : ""
+  luks_compliant                 = var.luks_compliant
+  luks_config                    = var.luks_config
+  luks_filesystem_device         = var.luks_filesystem_device
+  luks_format                    = var.luks_format
+  luks_wipeFileSystem            = var.luks_wipeFileSystem
+  luks_device                    = var.luks_device
+  luks_label                     = var.luks_label
+  luks_options                   = var.luks_options
+  luks_wipeVolume                = var.luks_wipeVolume
+  luks_name                      = var.luks_name
 }
 
 module "ibmcloud" {

--- a/var.tfvars
+++ b/var.tfvars
@@ -113,3 +113,14 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 #setup_snat                 = true
 
 #csi_driver_install         = false  #Set to true to enable installation of csi-driver.
+
+#luks_compliant              = false # Set it true if you prefer to use LUKS enable in OCP deployment
+#luks_config                 = [ { thumbprint = "", url = "" }, { thumbprint = "", url = "" }, { thumbprint = "", url = "" } ]
+#luks_filesystem_device      = "/dev/mapper/root"  #Set the Path of device to be luks encrypted 
+#luks_format                 = "xfs"  #Set the Format of the FileSystem to be luks encrypted
+#luks_wipeFileSystem         = true  #Configures the FileSystem to be wiped 
+#luks_device                 = "/dev/disk/by-partlabel/root"  #Set the Path of luks encrypted partition
+#luks_label                  = "luks-root"  #Set the value for user label of luks encrpted partition
+#luks_options                = ["--cipher", "aes-cbc-essiv:sha256"]  #Set List of luks options for the luks encryption
+#luks_wipeVolume             = true  #Configures the luks encrypted partition to be wiped 
+#luks_name                   = "root" #Set the value for the user label of Filesystem to be luks encrypted

--- a/variables.tf
+++ b/variables.tf
@@ -310,7 +310,7 @@ variable "install_playbook_repo" {
 variable "install_playbook_tag" {
   type        = string
   description = "Set the branch/tag name or commit# for using ocp4-playbooks repo"
-  default     = "5c3917506842adb205a4bad7750c084e769075b0"
+  default     = "df32ad3707436e086464576c6d2c7a3f6e97fa6b"
   # Checkout level for var.install_playbook_repo which is used for running ocp4 installations steps
 }
 
@@ -625,3 +625,68 @@ variable "rhcos_import_image_storage_type" {
   default     = "tier1"
 }
 
+################################################################
+# LUKS configuration variables
+################################################################
+variable "luks_compliant" {
+  type        = bool
+  description = "Set to true to enable usage of LUKS for OCP deployment."
+  default     = false
+}
+
+variable "luks_config" {
+  type = list(object({
+    thumbprint = string,
+    url        = string
+  }))
+  description = "List of tang servers and thumbprint to apply"
+  default     = []
+}
+
+variable "luks_filesystem_device" {
+  type        = string
+  description = "Path of device to be luks encrypted"
+  default     = "/dev/mapper/root"
+}
+
+variable "luks_format" {
+  type        = string
+  description = "Format of the FileSystem to be luks encrypted"
+  default     = "xfs"
+}
+
+variable "luks_wipeFileSystem" {
+  type        = bool
+  description = "Configures the FileSystem to be wiped"
+  default     = true
+}
+
+variable "luks_device" {
+  type        = string
+  description = "Path of luks encrypted partition"
+  default     = "/dev/disk/by-partlabel/root"
+}
+
+variable "luks_label" {
+  type        = string
+  description = "Variable for the user label of luks encrpted partition"
+  default     = "luks-root"
+}
+
+variable "luks_options" {
+  type        = list(string)
+  description = "List of luks options for the luks encryption"
+  default     = ["--cipher", "aes-cbc-essiv:sha256"]
+}
+
+variable "luks_wipeVolume" {
+  type        = bool
+  description = "Configures the luks encrypted partition to be wiped"
+  default     = true
+}
+
+variable "luks_name" {
+  type        = string
+  description = "Variable for the user label of Filesystem to be luks encrypted"
+  default     = "root"
+}


### PR DESCRIPTION
This PR is mainly related to LUKS encryption which is required for PCI profile compliance.
To achieve this we have followed below document
https://docs.openshift.com/container-platform/4.11/installing/install_config/installing-customizing.html

This PR contains the variables and code changes that are required for encrypting block device in LUKS2 format.
This feature will enable Luks Encryption using Tang Servers on all master/worker nodes.
By default the encryption is disabled. User need to enable it in var.tfvars file during OCP deployment and also need to provide the passphrase and URL for each tang server.

For more details related to ocp4-playbook changes please refer below PR:
https://github.com/ocp-power-automation/ocp4-playbooks/pull/173



**Note: This is Day-1 activity and can be achieved by running ansible playbook tasks.**

Signed-off-by: Gaurav Bankar <Gaurav.Bankar@ibm.com>
