### PR TITLE
enable multipathd by default across cluster nodes

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -312,23 +312,24 @@ dns_forwarders              = "1.1.1.1; 9.9.9.9"
 ```
 
 List of [day-1 kernel arguments](https://docs.openshift.com/container-platform/latest/installing/install_config/installing-customizing.html#installation-special-config-kargs_installing-customizing) for the cluster nodes.
-To add kernel arguments to master or worker nodes, using MachineConfig object and inject that object into the set of manifest files used by Ignition during cluster setup.
+To add kernel arguments to master or worker nodes, using MachineConfig object and inject that object into the set of manifest files used by Ignition during cluster setup. Use only if they are needed to complete the initial OCP installation. The automation will set `"rd.multipath=default"` and `"root=/dev/disk/by-label/dm-mpath-root"` by default.
 ```
 rhcos_pre_kernel_options        = []
 ```
 - Example 1
   ```
-  rhcos_pre_kernel_options   = ["rd.multipath=default","root=/dev/disk/by-label/dm-mpath-root"]
+  rhcos_pre_kernel_options   =  ["loglevel=7"]
   ```
 
-List of [kernel arguments](https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-working.html#nodes-nodes-kernel-arguments_nodes-nodes-working) for the cluster nodes.
+List of [kernel arguments](https://docs.openshift.com/container-platform/latest/post_installation_configuration/machine-configuration-tasks.html#nodes-nodes-kernel-arguments_post-install-machine-configur
+ation-tasks) for the cluster nodes.
 Note that this will be applied after the cluster is installed and all the nodes are in `Ready` status.
 ```
 rhcos_kernel_options        = []
 ```
 - Example 1
   ```
-  rhcos_kernel_options      = ["slub_max_order=0","loglevel=7"]
+  rhcos_kernel_options      = ["slub_max_order=0","enforcing=0"]
   ```
 
 This is a Map of [Node labels](https://kubernetes.io/docs/reference/labels-annotations-taints) and its values. Some of the well known labels such as `topology.kubernetes.io/region, topology.kubernetes.io/zone and node.kubernetes.io/instance-type` are automated. More custom labels can be added using the `node_labels` map variable.

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -107,6 +107,11 @@ locals {
 
   local_registry_ocp_image = "registry.${var.cluster_id}.${var.cluster_domain}:5000/${local.local_registry.ocp_release_repo}:${var.ocp_release_tag}"
 
+  // enable multipathd by default across cluster nodes
+  default_kernel_options        = ["rd.multipath=default", "root=/dev/disk/by-label/dm-mpath-root"]
+  rhcos_pre_kernel_options_keys = [for opt in var.rhcos_pre_kernel_options : split("=", opt)[0]]
+  rhcos_pre_kernel_options      = contains(local.rhcos_pre_kernel_options_keys, "rd.multipath") ? var.rhcos_pre_kernel_options : concat(var.rhcos_pre_kernel_options, local.default_kernel_options)
+
   install_vars = {
     bastion_vip              = var.bastion_vip
     cluster_id               = var.cluster_id
@@ -118,7 +123,7 @@ locals {
     release_image_override   = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
     enable_local_registry    = var.enable_local_registry
     fips_compliant           = var.fips_compliant
-    rhcos_pre_kernel_options = var.rhcos_pre_kernel_options
+    rhcos_pre_kernel_options = local.rhcos_pre_kernel_options
     rhcos_kernel_options     = var.rhcos_kernel_options
     node_labels              = merge(local.node_labels, var.node_labels)
     chrony_config            = var.chrony_config


### PR DESCRIPTION
If `rd.multipath=*` kernel option is provided we will use `rhcos_pre_kernel_options` value as it is.
If rd option is not provided, we will enable multipath by default by adding two options:
```
rd.multipath=default
root=/dev/disk/by-label/dm-mpath-root
```