### PR TITLE
Improve handling of shutdown and startup actions

### DIFF
--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -103,6 +103,7 @@ resource "ibm_pi_instance_action" "bootstrap_stop" {
   pi_cloud_instance_id = var.service_instance_id
   pi_instance_id       = ibm_pi_instance.bootstrap[count.index].instance_id
   pi_action            = "immediate-shutdown"
+  pi_health_status     = "WARNING"
 }
 
 #master
@@ -156,6 +157,7 @@ resource "ibm_pi_instance_action" "master_stop" {
   pi_cloud_instance_id = var.service_instance_id
   pi_instance_id       = ibm_pi_instance.master[count.index].instance_id
   pi_action            = "immediate-shutdown"
+  pi_health_status     = "WARNING"
 }
 
 resource "ibm_pi_volume" "master" {
@@ -221,6 +223,7 @@ resource "ibm_pi_instance_action" "worker_stop" {
   pi_cloud_instance_id = var.service_instance_id
   pi_instance_id       = ibm_pi_instance.worker[count.index].instance_id
   pi_action            = "immediate-shutdown"
+  pi_health_status     = "WARNING"
 }
 
 resource "null_resource" "remove_worker" {

--- a/ocp.tf
+++ b/ocp.tf
@@ -107,7 +107,8 @@ module "nodes" {
 }
 
 module "install" {
-  source = "./modules/5_install"
+  source     = "./modules/5_install"
+  depends_on = [module.nodes]
 
   service_instance_id            = var.service_instance_id
   region                         = var.ibmcloud_region


### PR DESCRIPTION
@yussufsh please consider this PR which helped resolve a production issue we had with tok04 past few weeks. It does two things:

1. Add an explicit dependency of the install module on the node module as there was no implicit dependency of the node start actions on the node stop actions because they are in different modules.

2. Add pi_health_status = "WARNING" to the node stop actions.  It seems in addition to SHUTOFF status the health was expected to be OK but in tok04 it was returning WARNING so would eventually timeout with context deadline exceeded. 