### PR TITLE
Remove deprecated oc adm drain option

### DIFF
--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -252,7 +252,7 @@ resource "null_resource" "remove_worker" {
     on_failure = continue
     inline = [<<EOF
 oc adm cordon ${self.triggers.node_prefix}worker-${count.index}.${self.triggers.cluster_id}.${self.triggers.cluster_domain}
-oc adm drain ${self.triggers.node_prefix}worker-${count.index}.${self.triggers.cluster_id}.${self.triggers.cluster_domain} --force --delete-local-data --ignore-daemonsets --timeout=180s
+oc adm drain ${self.triggers.node_prefix}worker-${count.index}.${self.triggers.cluster_id}.${self.triggers.cluster_domain} --force --delete-emptydir-data --ignore-daemonsets --timeout=100s
 oc delete node ${self.triggers.node_prefix}worker-${count.index}.${self.triggers.cluster_id}.${self.triggers.cluster_domain}
 EOF
     ]


### PR DESCRIPTION
Fixes https://github.com/ocp-power-automation/ocp4-upi-powervs/issues/487

1. Removed deprecated oc adm drain option `delete-local-data` and replaced with `delete-emptydir-data`
2. Decreased the drain timeout to 100s as the overall null_resource timeout is 2m.