### PR TITLE
enforce resource_group constraints on VPC resources #499

### DIFF
--- a/modules/7_ibmcloud/load_balancer.tf
+++ b/modules/7_ibmcloud/load_balancer.tf
@@ -32,6 +32,7 @@ locals {
 
 resource "ibm_is_lb" "load_balancer_internal" {
   name            = "${var.name_prefix}internal-loadbalancer"
+  resource_group  = data.ibm_is_vpc.vpc.resource_group
   subnets         = [var.vpc_subnet_id]
   security_groups = [ibm_is_security_group.ocp_security_group.id]
   type            = "private"
@@ -39,6 +40,7 @@ resource "ibm_is_lb" "load_balancer_internal" {
 
 resource "ibm_is_lb" "load_balancer_external" {
   name            = "${var.name_prefix}external-loadbalancer"
+  resource_group  = data.ibm_is_vpc.vpc.resource_group
   subnets         = [var.vpc_subnet_id]
   security_groups = [ibm_is_security_group.ocp_security_group.id]
   type            = "public"

--- a/modules/7_ibmcloud/security_group.tf
+++ b/modules/7_ibmcloud/security_group.tf
@@ -26,8 +26,9 @@ data "ibm_is_vpc" "vpc" {
 }
 
 resource "ibm_is_security_group" "ocp_security_group" {
-  name = "${var.name_prefix}ocp-sec-group"
-  vpc  = data.ibm_is_vpc.vpc.id
+  name           = "${var.name_prefix}ocp-sec-group"
+  vpc            = data.ibm_is_vpc.vpc.id
+  resource_group = data.ibm_is_vpc.vpc.resource_group
 }
 
 resource "ibm_is_security_group_rule" "inbound_ports" {


### PR DESCRIPTION
This code is marked work in progress

@Prajyot-Parab this is the fix for: 

```
╷
│ Error: remote-exec provisioner error
│
│   with module.install.null_resource.bootstrap_complete,
│   on modules/5_install/install.tf line 463, in resource "null_resource" "bootstrap_complete":
│  463:   provisioner "remote-exec" {
│
│ error executing "/tmp/terraform_1140640526.sh": Process exited with status 2
Error: [ERROR] Error while creating Security Group user does not have permission to use default resource group
│ {
│     "StatusCode": 403,
...
"Result": {
│         "errors": [
│             {
│                 "code": "not_authorized",
│                 "message": "user does not have permission to use default resource group"
│             }
│         ],
```

cc: @Chandan-Abhyankar 