### PR TITLE
Add support for creating IBM Cloud services

### DIFF
--- a/docs/ocp_prereqs_powervs.md
+++ b/docs/ocp_prereqs_powervs.md
@@ -61,10 +61,11 @@ Two options are available to enable communication over the private network.
 
 *Option 1*
 
-You can use the IBM Cloud CLI with the latest power-iaas plug-in (version 0.3.4 or later) to enable a private network communication.
-Refer: https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-managing-cloud-connections
+Now, the automation can create a [Cloud Connection](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-cloud-connections) for you. IBM Cloud connection creates a Direct Link (2.0) Connect instance to connect your Power Virtual Server instances to the IBM Cloud resources within your account.
 
-This requires attaching the private network to an IBM Cloud Direct Link Connect 2.0 connection.
+You can now use [IBM Cloud Transit Gateway](https://cloud.ibm.com/docs/transit-gateway?topic=transit-gateway-about) to manage the connection of your Power Virtual Server instances to the IBM Cloud resources. This feature is available when you set `use_ibm_cloud_services = true`. Skip the steps given below and please refer to [var.tfvars](./var.tfvars-doc.md#using-ibm-cloud-services) for more details.
+
+Use the IBM Cloud CLI with the latest power-iaas plug-in (version 0.3.4 or later) to enable a private network communication. This requires attaching the private network to an [IBM Cloud Direct Link Connect 2.0 connection](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-managing-cloud-connections).
 Perform the following steps to enable private network communication by attaching to the Direct Link Connect 2.0 connection.
 
 - Select a specific service instance
@@ -189,8 +190,12 @@ Click "**Continue**" to accept agreements, and then Click "**Submit case**".
 
 This usually takes a day to get enabled.
 
-## RHCOS and RHEL/CentOS 8.X Images for OpenShift
-RHEL image is used for bastion and RHCOS is used for the OpenShift cluster nodes.
+## RHCOS and RHEL/CentOS Images for OpenShift
+RHEL/CentOS (8.X or 9.X) image is used for bastion and RHCOS is used for the OpenShift cluster nodes.
+
+You can now use stock images for the bastion node. The automation will copy it to your PowerVS service instance if not already available.
+
+For RHCOS (OpenShift cluster nodes) you can let the automation import it for you from public COS bucket by setting the variable `rhcos_import_image = true`. Skip the steps given below for RHCOS and please refer to [var.tfvars](./var.tfvars-doc.md#openshift-cluster-details) for more details. Value of `rhcos_import_image_filename` can be refered from [rhcos-table.md](./rhcos-table.md) specific to the required OpenShit version.
 
 You'll need to create [OVA](https://en.wikipedia.org/wiki/Open_Virtualization_Format) formatted images for RHEL and RHCOS, upload them to IBM Cloud Object storage and then import these images as boot images in your PowerVS service instance.
 
@@ -206,6 +211,7 @@ Further, the image disk should be minimum of 120 GB in size.
   - RHCOS Qcow2 image is available at [latest stable](https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/latest/rhcos-openstack.ppc64le.qcow2.gz) OR [pre-release](https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/pre-release/latest/rhcos-openstack.ppc64le.qcow2.gz)
 
 Note: RHCOS image version is tied to the specific OCP release. For example RHCOS-4.6 image needs to be used for OCP 4.6 release.
+
 ### Uploading to IBM Cloud Object Storage
 
 - **Create IBM Cloud Object Storage service and bucket**

--- a/modules/1_prepare/outputs.tf
+++ b/modules/1_prepare/outputs.tf
@@ -54,3 +54,8 @@ output "bastion_external_vip" {
   depends_on = [null_resource.bastion_init]
   value      = local.bastion_count > 1 ? ibm_pi_network_port.bastion_internal_vip[0].public_ip : ""
 }
+
+output "cloud_connection_name" {
+  depends_on = [ibm_pi_cloud_connection.cloud_connection, time_sleep.wait_for_cc]
+  value      = var.create_cloud_connection ? ibm_pi_cloud_connection.cloud_connection[0].pi_cloud_connection_name : ""
+}

--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -441,3 +441,22 @@ resource "ibm_pi_network_port" "bastion_internal_vip" {
   pi_network_name      = ibm_pi_network.public_network.pi_network_name
   pi_cloud_instance_id = var.service_instance_id
 }
+
+resource "ibm_pi_cloud_connection" "cloud_connection" {
+  count = var.create_cloud_connection ? 1 : 0
+
+  pi_cloud_instance_id                = var.service_instance_id
+  pi_cloud_connection_name            = "${var.cluster_id}-cc"
+  pi_cloud_connection_speed           = 100
+  pi_cloud_connection_global_routing  = true
+  pi_cloud_connection_transit_enabled = true
+  pi_cloud_connection_networks        = [data.ibm_pi_network.network.id]
+}
+# Give some time to change the status
+# after cc is created
+resource "time_sleep" "wait_for_cc" {
+  count = var.create_cloud_connection ? 1 : 0
+
+  depends_on      = [ibm_pi_cloud_connection.cloud_connection]
+  create_duration = "3m"
+}

--- a/modules/1_prepare/variables.tf
+++ b/modules/1_prepare/variables.tf
@@ -80,3 +80,5 @@ variable "volume_shareable" {}
 variable "setup_squid_proxy" {}
 variable "proxy" {}
 variable "fips_compliant" {}
+
+variable "create_cloud_connection" {}

--- a/modules/1_prepare/versions.tf
+++ b/modules/1_prepare/versions.tf
@@ -22,11 +22,14 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
     null = {
       source  = "hashicorp/null"
       version = "~> 3.2"
+    }
+    time = {
+      source = "hashicorp/time"
     }
   }
   required_version = ">= 1.2.0"

--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -150,6 +150,10 @@ resource "ibm_pi_instance" "master" {
   pi_network {
     network_id = data.ibm_pi_network.network.id
   }
+
+  lifecycle {
+    ignore_changes = [pi_storage_pool_affinity]
+  }
 }
 resource "ibm_pi_instance_action" "master_stop" {
   count = var.master["count"]
@@ -215,6 +219,10 @@ resource "ibm_pi_instance" "worker" {
 
   pi_network {
     network_id = data.ibm_pi_network.network.id
+  }
+
+  lifecycle {
+    ignore_changes = [pi_storage_pool_affinity]
   }
 }
 resource "ibm_pi_instance_action" "worker_stop" {

--- a/modules/4_nodes/versions.tf
+++ b/modules/4_nodes/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
     ignition = {
       source  = "community-terraform-providers/ignition"

--- a/modules/5_install/versions.tf
+++ b/modules/5_install/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
 
   }

--- a/modules/7_ibmcloud/load_balancer.tf
+++ b/modules/7_ibmcloud/load_balancer.tf
@@ -32,16 +32,16 @@ locals {
 
 resource "ibm_is_lb" "load_balancer_internal" {
   name            = "${var.name_prefix}internal-loadbalancer"
-  resource_group  = data.ibm_is_vpc.vpc.resource_group
-  subnets         = [var.vpc_subnet_id]
+  resource_group  = local.resource_group_id
+  subnets         = [local.vpc_subnet_id]
   security_groups = [ibm_is_security_group.ocp_security_group.id]
   type            = "private"
 }
 
 resource "ibm_is_lb" "load_balancer_external" {
   name            = "${var.name_prefix}external-loadbalancer"
-  resource_group  = data.ibm_is_vpc.vpc.resource_group
-  subnets         = [var.vpc_subnet_id]
+  resource_group  = local.resource_group_id
+  subnets         = [local.vpc_subnet_id]
   security_groups = [ibm_is_security_group.ocp_security_group.id]
   type            = "public"
 }

--- a/modules/7_ibmcloud/outputs.tf
+++ b/modules/7_ibmcloud/outputs.tf
@@ -21,3 +21,7 @@
 output "load_balancer_hostname" {
   value = ibm_is_lb.load_balancer_external.hostname
 }
+
+output "vpc_cidr" {
+  value = local.vpc_subnet_cidr
+}

--- a/modules/7_ibmcloud/security_group.tf
+++ b/modules/7_ibmcloud/security_group.tf
@@ -21,14 +21,11 @@
 locals {
   tcp_ports = [22623, 6443, 443, 80]
 }
-data "ibm_is_vpc" "vpc" {
-  name = var.vpc_name
-}
 
 resource "ibm_is_security_group" "ocp_security_group" {
   name           = "${var.name_prefix}ocp-sec-group"
-  vpc            = data.ibm_is_vpc.vpc.id
-  resource_group = data.ibm_is_vpc.vpc.resource_group
+  vpc            = local.vpc_id
+  resource_group = local.resource_group_id
 }
 
 resource "ibm_is_security_group_rule" "inbound_ports" {

--- a/modules/7_ibmcloud/tgw.tf
+++ b/modules/7_ibmcloud/tgw.tf
@@ -1,0 +1,64 @@
+################################################################
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# ©Copyright IBM Corp. 2023
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################
+
+data "ibm_tg_gateway" "transit_gateway" {
+  count = local.create_tgw ? 0 : 1
+
+  name = var.ibm_cloud_tgw
+}
+
+resource "ibm_tg_gateway" "transit_gateway" {
+  count = local.create_tgw ? 1 : 0
+
+  name           = "${var.cluster_id}-tgw"
+  location       = var.vpc_region
+  global         = true
+  resource_group = local.resource_group_id
+}
+
+resource "ibm_tg_connection" "tg_connection_vpc" {
+  count = local.create_vpc || local.create_tgw ? 1 : 0
+
+  gateway      = local.tgw_id
+  network_type = "vpc"
+  name         = "${var.cluster_id}-conn-vpc"
+  network_id   = local.vpc_crn
+}
+
+resource "ibm_tg_connection" "tg_connection_powervs" {
+  count = var.is_new_cloud_connection || local.create_tgw ? 1 : 0
+
+  gateway      = local.tgw_id
+  network_type = var.is_per ? "power_virtual_server" : "directlink"
+  name         = "${var.cluster_id}-conn-powervs"
+  network_id   = var.is_per ? var.ibm_cloud_tgw_net : data.ibm_dl_gateway.dl[0].crn
+}
+
+# If power workspace is given not required
+data "ibm_dl_gateway" "dl" {
+  count      = var.is_per ? 0 : 1
+  depends_on = [var.ibm_cloud_tgw_net]
+  name       = var.ibm_cloud_tgw_net
+}
+
+locals {
+  create_tgw = var.ibm_cloud_tgw == "" ? true : false
+  tgw_id     = local.create_tgw ? resource.ibm_tg_gateway.transit_gateway[0].id : data.ibm_tg_gateway.transit_gateway[0].id
+}

--- a/modules/7_ibmcloud/variables.tf
+++ b/modules/7_ibmcloud/variables.tf
@@ -28,7 +28,9 @@ variable "name_prefix" {}
 variable "node_prefix" {}
 
 variable "vpc_name" {}
-variable "vpc_subnet_id" {}
+variable "vpc_subnet_name" {}
+variable "vpc_region" {}
+variable "ibm_cloud_resource_group" {}
 variable "ibm_cloud_cis_crn" {}
 
 variable "bastion_count" {}

--- a/modules/7_ibmcloud/variables.tf
+++ b/modules/7_ibmcloud/variables.tf
@@ -32,6 +32,10 @@ variable "vpc_subnet_name" {}
 variable "vpc_region" {}
 variable "ibm_cloud_resource_group" {}
 variable "ibm_cloud_cis_crn" {}
+variable "ibm_cloud_tgw" {}
+variable "ibm_cloud_tgw_net" {}
+variable "is_per" {}
+variable "is_new_cloud_connection" {}
 
 variable "bastion_count" {}
 variable "bootstrap_count" {}

--- a/modules/7_ibmcloud/versions.tf
+++ b/modules/7_ibmcloud/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
   }
   required_version = ">= 1.2.0"

--- a/modules/7_ibmcloud/vpc.tf
+++ b/modules/7_ibmcloud/vpc.tf
@@ -1,0 +1,63 @@
+################################################################
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Licensed Materials - Property of IBM
+#
+# ©Copyright IBM Corp. 2023
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################
+
+locals {
+  create_vpc        = var.vpc_name == ""
+  create_subnet     = var.vpc_name == "" || var.vpc_subnet_name == ""
+  vpc_id            = local.create_vpc ? ibm_is_vpc.vpc[0].id : data.ibm_is_vpc.vpc[0].id
+  vpc_subnet_id     = local.create_subnet ? ibm_is_subnet.subnet[0].id : data.ibm_is_subnet.subnet[0].id
+  vpc_subnet_cidr   = local.create_subnet ? ibm_is_subnet.subnet[0].ipv4_cidr_block : data.ibm_is_subnet.subnet[0].ipv4_cidr_block
+  resource_group_id = data.ibm_resource_group.group.id
+}
+
+data "ibm_is_vpc" "vpc" {
+  count = local.create_vpc ? 0 : 1
+
+  name = var.vpc_name
+}
+
+data "ibm_is_subnet" "subnet" {
+  count = local.create_subnet ? 0 : 1
+
+  name = var.vpc_subnet_name
+}
+
+data "ibm_resource_group" "group" {
+  name = var.ibm_cloud_resource_group
+}
+
+resource "ibm_is_vpc" "vpc" {
+  count = local.create_vpc ? 1 : 0
+
+  name           = "${var.cluster_id}-vpc"
+  resource_group = local.resource_group_id
+  tags           = [var.cluster_id, "powervs-openshift"]
+}
+
+resource "ibm_is_subnet" "subnet" {
+  count = local.create_subnet ? 1 : 0
+
+  name                     = "${var.cluster_id}-subnet"
+  vpc                      = local.create_vpc ? ibm_is_vpc.vpc[0].id : data.ibm_is_vpc.vpc[0].id
+  resource_group           = local.resource_group_id
+  total_ipv4_address_count = 256
+  zone                     = "${var.vpc_region}-1"
+  tags                     = [var.cluster_id, "powervs-openshift"]
+}

--- a/modules/7_ibmcloud/vpc.tf
+++ b/modules/7_ibmcloud/vpc.tf
@@ -22,9 +22,10 @@ locals {
   create_vpc        = var.vpc_name == ""
   create_subnet     = var.vpc_name == "" || var.vpc_subnet_name == ""
   vpc_id            = local.create_vpc ? ibm_is_vpc.vpc[0].id : data.ibm_is_vpc.vpc[0].id
+  vpc_crn           = local.create_vpc ? ibm_is_vpc.vpc[0].crn : data.ibm_is_vpc.vpc[0].crn
   vpc_subnet_id     = local.create_subnet ? ibm_is_subnet.subnet[0].id : data.ibm_is_subnet.subnet[0].id
   vpc_subnet_cidr   = local.create_subnet ? ibm_is_subnet.subnet[0].ipv4_cidr_block : data.ibm_is_subnet.subnet[0].ipv4_cidr_block
-  resource_group_id = data.ibm_resource_group.group.id
+  resource_group_id = local.create_vpc ? data.ibm_resource_group.group.id : data.ibm_is_vpc.vpc[0].resource_group
 }
 
 data "ibm_is_vpc" "vpc" {

--- a/modules/8_custom/versions.tf
+++ b/modules/8_custom/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
   }
   required_version = ">= 1.2.0"

--- a/ocp.tf
+++ b/ocp.tf
@@ -35,12 +35,6 @@ locals {
   }
 }
 
-data "ibm_is_subnet" "vpc_subnet" {
-  provider = ibm.vpc
-  count    = var.use_ibm_cloud_services ? 1 : 0
-  name     = var.ibm_cloud_vpc_subnet_name
-}
-
 module "prepare" {
   source = "./modules/1_prepare"
 
@@ -180,7 +174,7 @@ module "install" {
   csi_driver_install             = var.csi_driver_install
   csi_driver_type                = var.csi_driver_type
   csi_driver_version             = var.csi_driver_version
-  vpc_cidr                       = var.use_ibm_cloud_services ? data.ibm_is_subnet.vpc_subnet[0].ipv4_cidr_block : ""
+  vpc_cidr                       = var.use_ibm_cloud_services ? module.ibmcloud[0].vpc_cidr : ""
   luks_compliant                 = var.luks_compliant
   luks_config                    = var.luks_config
   luks_filesystem_device         = var.luks_filesystem_device
@@ -210,22 +204,24 @@ module "ibmcloud" {
     ibm = ibm.vpc
   }
 
-  cluster_domain    = module.nodes.cluster_domain
-  cluster_id        = local.cluster_id
-  name_prefix       = local.name_prefix
-  node_prefix       = local.node_prefix
-  bastion_count     = lookup(var.bastion, "count", 1)
-  bootstrap_count   = var.bootstrap["count"]
-  master_count      = var.master["count"]
-  worker_count      = var.worker["count"]
-  bastion_vip       = module.prepare.bastion_vip
-  bastion_ip        = module.prepare.bastion_ip
-  bootstrap_ip      = module.nodes.bootstrap_ip
-  master_ips        = module.nodes.master_ips
-  worker_ips        = module.nodes.worker_ips
-  vpc_name          = var.ibm_cloud_vpc_name
-  vpc_subnet_id     = var.use_ibm_cloud_services ? data.ibm_is_subnet.vpc_subnet[0].id : ""
-  ibm_cloud_cis_crn = var.ibm_cloud_cis_crn
+  cluster_domain           = module.nodes.cluster_domain
+  cluster_id               = local.cluster_id
+  name_prefix              = local.name_prefix
+  node_prefix              = local.node_prefix
+  bastion_count            = lookup(var.bastion, "count", 1)
+  bootstrap_count          = var.bootstrap["count"]
+  master_count             = var.master["count"]
+  worker_count             = var.worker["count"]
+  bastion_vip              = module.prepare.bastion_vip
+  bastion_ip               = module.prepare.bastion_ip
+  bootstrap_ip             = module.nodes.bootstrap_ip
+  master_ips               = module.nodes.master_ips
+  worker_ips               = module.nodes.worker_ips
+  vpc_name                 = var.ibm_cloud_vpc_name
+  vpc_subnet_name          = var.ibm_cloud_vpc_subnet_name
+  vpc_region               = local.iaas_vpc_region
+  ibm_cloud_resource_group = var.ibm_cloud_resource_group
+  ibm_cloud_cis_crn        = var.ibm_cloud_cis_crn
 }
 
 module "custom" {

--- a/var.tfvars
+++ b/var.tfvars
@@ -58,8 +58,9 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 
 ### Using IBM Cloud Services
 #use_ibm_cloud_services    = true
-#ibm_cloud_vpc_name        = "ocp-vpc"
-#ibm_cloud_vpc_subnet_name = "ocp-subnet"
+#ibm_cloud_vpc_name        = ""
+#ibm_cloud_vpc_subnet_name = ""
+#ibm_cloud_resource_group  = "Default"
 # iaas_vpc_region          = ""               # if empty, will default to ibmcloud_region.
 # ibm_cloud_cis_crn        = "crn:v1:bluemix:public:internet-svcs:global:a/<account_id>:<cis_instance_id>::"
 

--- a/var.tfvars
+++ b/var.tfvars
@@ -57,13 +57,14 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 #fips_compliant      = false   # Set it true if you prefer to use FIPS enable in ocp deployment
 
 ### Using IBM Cloud Services
-#use_ibm_cloud_services    = true
-#ibm_cloud_vpc_name        = ""
-#ibm_cloud_vpc_subnet_name = ""
-#ibm_cloud_resource_group  = "Default"
-# iaas_vpc_region          = ""               # if empty, will default to ibmcloud_region.
-# ibm_cloud_cis_crn        = "crn:v1:bluemix:public:internet-svcs:global:a/<account_id>:<cis_instance_id>::"
-
+#use_ibm_cloud_services     = true
+#ibm_cloud_vpc_name         = ""
+#ibm_cloud_vpc_subnet_name  = ""
+#ibm_cloud_resource_group   = "Default"
+# iaas_vpc_region           = ""               # if empty, will default to ibmcloud_region.
+# ibm_cloud_cis_crn         = "crn:v1:bluemix:public:internet-svcs:global:a/<account_id>:<cis_instance_id>::"
+# ibm_cloud_tgw             = ""  # Name of existing Transit Gateway where VPC and PowerVS targets are already added.
+# ibm_cloud_connection_name = ""  # Name of the cloud connection which is already attached to the above Transit Gateway.
 
 ### Misc Customizations
 

--- a/variables.tf
+++ b/variables.tf
@@ -219,18 +219,23 @@ variable "rhel_smt" {
 ################################################################
 variable "use_ibm_cloud_services" {
   type        = bool
-  description = "Experimental: Flag to use Internet Services (CIS) and Loadbalancer services on VPC instead of bastion services. Please set variables setup_snat=true and setup_squid_proxy=false"
+  description = "Flag to use Internet Services (CIS) and Loadbalancer services on VPC instead of bastion services. Please set variables setup_snat=true and setup_squid_proxy=false"
   default     = false
 }
 variable "ibm_cloud_vpc_name" {
   type        = string
-  description = "Name of the IBM Cloud Virtual Private Clouds (VPC) to setup the load balancer. Required if use_ibm_cloud_services = true."
-  default     = "ocp-vpc"
+  description = "Name of the IBM Cloud Virtual Private Clouds (VPC) to setup the load balancer. By default will create a new VPC when use_ibm_cloud_services=true."
+  default     = ""
 }
 variable "ibm_cloud_vpc_subnet_name" {
   type        = string
-  description = "Name of the VPC subnet having DirectLink access to the private network. Required if use_ibm_cloud_services = true."
-  default     = "ocp-subnet"
+  description = "Name of the VPC subnet having DirectLink access to the private network. By default will create a new VPC Subnet when use_ibm_cloud_services=true."
+  default     = ""
+}
+variable "ibm_cloud_resource_group" {
+  type        = string
+  description = "Name of the IBM Cloud Resource Group where you want to create the VPC. Ignore if VPC and Subnet names are provided."
+  default     = "Default"
 }
 variable "iaas_vpc_region" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -219,7 +219,7 @@ variable "rhel_smt" {
 ################################################################
 variable "use_ibm_cloud_services" {
   type        = bool
-  description = "Flag to use Internet Services (CIS) and Loadbalancer services on VPC instead of bastion services. Please set variables setup_snat=true and setup_squid_proxy=false"
+  description = "Flag to use Internet Services (CIS) and Loadbalancer services on VPC instead of bastion services."
   default     = false
 }
 variable "ibm_cloud_vpc_name" {
@@ -247,6 +247,16 @@ variable "ibm_cloud_cis_crn" {
   # cli: `ibmcloud resource service-instance <cis name>`
   type        = string
   description = "IBM Cloud Intenet Service instance CRN. Required if use_ibm_cloud_services = true."
+  default     = ""
+}
+variable "ibm_cloud_tgw" {
+  type        = string
+  description = "Name of the existing transit gateway. If empty a new transit gateway will be created and connect VPC & PowerVS to it."
+  default     = ""
+}
+variable "ibm_cloud_connection_name" {
+  type        = string
+  description = "Name of the existing cloud connection. If empty a new cloud connection will be created. Not applicable for PER."
   default     = ""
 }
 
@@ -385,7 +395,7 @@ variable "chrony_config_servers" {
 
 variable "setup_snat" {
   type        = bool
-  description = "IMPORTANT: This is an experimental feature. Flag to configure bastion as SNAT and use the router on all cluster nodes"
+  description = "Flag to configure bastion as SNAT and use the router on all cluster nodes"
   default     = true
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "ibm-cloud/ibm"
-      version = "~> 1.54.0"
+      version = "1.60.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
1. Create a new IBM Cloud VPC if not provided while using IBM Cloud services
2. Create a new Subnet in VPC if not provided
3. Create a Transit Gateway and attach VPC and PowerVS connection to it.
4. Create a Cloud Connection (non-PER) if not provided.

**Important Note:** This may break existing flows. Users should set the transit gateway name and cloud connection name if pre-created or the automation will try to create it. Transit Gateway is a new way, we will remove cloud connection once all locations are PER enabled. If you still need to use the old code without the Transit Gateway then please use the [tag v5.0.0](https://github.com/ocp-power-automation/ocp4-upi-powervs/releases/tag/v5.0.0).