### PR TITLE
Replace the local registry image with the official multi-arch registry image

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -263,7 +263,7 @@ The following variables can be used for disconnected install by using a local mi
 
 ```
 enable_local_registry      = false  #Set to true to enable usage of local registry for restricted network install.
-local_registry_image       = "docker.io/ibmcom/registry-ppc64le:2.6.2.5"
+local_registry_image       = "docker.io/library/registry:2"
 ocp_release_tag            = "4.4.9-ppc64le"
 ocp_release_name           = "ocp-release"
 ```

--- a/var.tfvars
+++ b/var.tfvars
@@ -69,7 +69,7 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 ### Misc Customizations
 
 #enable_local_registry      = false  #Set to true to enable usage of local registry for restricted network install.
-#local_registry_image       = "docker.io/ibmcom/registry-ppc64le:2.6.2.5"
+#local_registry_image       = "docker.io/library/registry:2"
 #ocp_release_tag            = "4.4.9-ppc64le"
 #ocp_release_name           = "ocp-release"
 #release_image_override     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -580,7 +580,7 @@ variable "enable_local_registry" {
 variable "local_registry_image" {
   type        = string
   description = "Name of the image used for creating local registry container."
-  default     = "docker.io/ibmcom/registry-ppc64le:2.6.2.5"
+  default     = "docker.io/library/registry:2"
 }
 
 variable "ocp_release_tag" {


### PR DESCRIPTION
Fixes an issue where the image mirrored had a different digest and was causing a `Manifest does not match provided manifest digest` error when pulled using SHA value.

The PR replaces the old  `docker.io/ibmcom/registry-ppc64le:2.6.2.5` image with the official multi-arch image `docker.io/library/registry:2`