### PR TITLE
OPENSHIFTP-174: generate a stable graph for the load balancer members

### DIFF
--- a/modules/7_ibmcloud/load_balancer.tf
+++ b/modules/7_ibmcloud/load_balancer.tf
@@ -20,11 +20,12 @@
 
 ################################################################
 ##### Network topology requirements
-##### Ref: https://docs.openshift.com/container-platform/4.7/installing/installing_platform_agnostic/installing-platform-agnostic.html
+##### Ref: https://docs.openshift.com/container-platform/4.16/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-network-user-infra_installing-platform-agnostic
+##### Note: You remove the bootstrap machine from the load balancer after the bootstrap machine initializes the cluster control plane.
 ################################################################
 
 locals {
-  api_servers        = var.bootstrap_count == 0 ? var.master_ips : concat([var.bootstrap_ip], var.master_ips)
+  api_servers        = var.bootstrap_count == 0 ? var.master_ips : concat(var.master_ips, [var.bootstrap_ip])
   api_servers_count  = var.bootstrap_count + var.master_count
   apps_servers       = var.worker_count == 0 ? var.master_ips : var.worker_ips
   apps_servers_count = var.worker_count == 0 ? var.master_count : var.worker_count


### PR DESCRIPTION
Load Balancer Members graph is unstable. You can see the IPs change for all the members when the bootstrap count is moved to zero. There is a bug in the load_balancer.tf that makes it unstable. This is the fix.

```
[1m  # module.ibmcloud[0].ibm_is_lb_pool_member.api_member_external[0][0m will be updated in-place
[33m~[0m[0m target_address      = "192.168.200.185" [33m->[0m[0m "192.168.200.84"

[1m  # module.ibmcloud[0].ibm_is_lb_pool_member.api_member_external[1][0m will be updated in-place
[33m~[0m[0m target_address      = "192.168.200.84" [33m->[0m[0m "192.168.200.236"

[1m  # module.ibmcloud[0].ibm_is_lb_pool_member.api_member_external[2][0m will be updated in-place
[33m~[0m[0m target_address      = "192.168.200.236" [33m->[0m[0m "192.168.200.175"

[1m  # module.ibmcloud[0].ibm_is_lb_pool_member.api_member_external[3][0m will be [1m[31mdestroyed[0m
[31m-[0m[0m target_address      = "192.168.200.175" [90m-> null[0m[0m
```