### PR TITLE
OPENSHIFTP-8: add fips enablement for 4.16 and higher

### DIFF
--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -90,6 +90,7 @@ locals {
     # trying to start named and haproxy
     # TODO: This is hardcoded to 9.9.9.9 to use external nameserver. Need to read from dns_forwarders.
     ext_dns = var.use_ibm_cloud_services ? "9.9.9.9" : ""
+    fips    = var.fips_compliant
   }
 
   helpernode_inventory = {
@@ -589,11 +590,3 @@ resource "null_resource" "csi_driver_install" {
   }
 }
 
-resource "ibm_pi_instance_action" "fips_bastion_reboot" {
-  depends_on = [null_resource.config, null_resource.setup_snat, null_resource.configure_public_vip, null_resource.external_services, null_resource.pre_install, null_resource.install, null_resource.powervs_config, null_resource.upgrade, null_resource.csi_driver_install]
-  count      = var.fips_compliant ? var.bastion_count : 0
-
-  pi_cloud_instance_id = var.service_instance_id
-  pi_instance_id       = "${var.name_prefix}bastion-${count.index}"
-  pi_action            = "soft-reboot"
-}

--- a/modules/5_install/templates/helpernode_vars.yaml
+++ b/modules/5_install/templates/helpernode_vars.yaml
@@ -89,3 +89,4 @@ ocp_install_kernel: "file:///dev/null"
 
 # This is required for latest helpernode. TODO: Remove when https://github.com/RedHatOfficial/ocp4-helpernode/pull/140 is merged
 helm_source: "https://get.helm.sh/helm-v3.3.4-linux-ppc64le.tar.gz"
+fips: ${fips}

--- a/variables.tf
+++ b/variables.tf
@@ -306,7 +306,7 @@ variable "helpernode_repo" {
 variable "helpernode_tag" {
   type        = string
   description = "Set the branch/tag name or commit# for using ocp4-helpernode repo"
-  default     = "94b8a123308f3566835a8ea2f189b204f77af88c"
+  default     = "d1ab538df6aeba915bf056f7983a60a68717d4d9"
   # Checkout level for var.helpernode_repo which is used for setting up services required on bastion node
 }
 


### PR DESCRIPTION
upgrading the ocp4-helpernode tag version, and adding a reboot to support FIPS cluster creation.

CC: @prb112  
