### PR TITLE
Add qe_only_disable_image_policy flag for QE testing

### DIFF
--- a/docs/var.tfvars-doc.md
+++ b/docs/var.tfvars-doc.md
@@ -273,6 +273,11 @@ This variable can be used for trying out custom OpenShift install image for deve
 release_image_override     = ""
 ```
 
+This variable is used to disable ClusterImagePolicy for QE testing purposes. Set to `true` to disable the ClusterImagePolicy. IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode.
+```
+qe_only_disable_image_policy = false
+```
+
 These variables specify the ansible playbooks that are used for OpenShift install and post-install customizations.
 ```
 helpernode_repo            = "https://github.com/redhat-cop/ocp4-helpernode"

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -120,27 +120,28 @@ locals {
   rhcos_pre_kernel_options      = contains(local.rhcos_pre_kernel_options_keys, "rd.multipath") ? var.rhcos_pre_kernel_options : concat(var.rhcos_pre_kernel_options, local.default_kernel_options)
 
   install_vars = {
-    bastion_vip              = var.bastion_vip
-    cluster_id               = var.cluster_id
-    cluster_domain           = var.cluster_domain
-    pull_secret              = var.pull_secret
-    public_ssh_key           = var.public_key
-    storage_type             = var.storage_type
-    log_level                = var.log_level
-    release_image_override   = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
-    enable_local_registry    = var.enable_local_registry
-    fips_compliant           = var.fips_compliant
-    rhcos_pre_kernel_options = local.rhcos_pre_kernel_options
-    rhcos_kernel_options     = var.rhcos_kernel_options
-    node_labels              = merge(local.node_labels, var.node_labels)
-    chrony_config            = var.chrony_config
-    chrony_config_servers    = var.chrony_config_servers
-    chrony_allow_range       = var.cidr
-    setup_squid_proxy        = var.setup_squid_proxy
-    squid_source_range       = var.cidr
-    proxy_url                = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
-    no_proxy                 = var.cidr
-    cni_network_provider     = var.cni_network_provider
+    bastion_vip                  = var.bastion_vip
+    cluster_id                   = var.cluster_id
+    cluster_domain               = var.cluster_domain
+    pull_secret                  = var.pull_secret
+    public_ssh_key               = var.public_key
+    storage_type                 = var.storage_type
+    log_level                    = var.log_level
+    release_image_override       = var.enable_local_registry ? local.local_registry_ocp_image : var.release_image_override
+    qe_only_disable_image_policy = var.qe_only_disable_image_policy
+    enable_local_registry        = var.enable_local_registry
+    fips_compliant               = var.fips_compliant
+    rhcos_pre_kernel_options     = local.rhcos_pre_kernel_options
+    rhcos_kernel_options         = var.rhcos_kernel_options
+    node_labels                  = merge(local.node_labels, var.node_labels)
+    chrony_config                = var.chrony_config
+    chrony_config_servers        = var.chrony_config_servers
+    chrony_allow_range           = var.cidr
+    setup_squid_proxy            = var.setup_squid_proxy
+    squid_source_range           = var.cidr
+    proxy_url                    = local.proxy.server == "" ? "" : "http://${local.proxy.user_pass}${local.proxy.server}:${local.proxy.port}"
+    no_proxy                     = var.cidr
+    cni_network_provider         = var.cni_network_provider
     # Set CNI network MTU to MTU - 100 for OVNKubernetes and MTU - 50 for OpenShiftSDN(default).
     # Add new conditions here when we have more network providers
     cni_network_mtu               = var.cni_network_provider == "OVNKubernetes" ? var.private_network_mtu - 100 : var.private_network_mtu - 50

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -10,6 +10,7 @@ workdir: ~/openstack-upi
 storage_type: ${storage_type}
 log_level: ${log_level}
 release_image_override: '${release_image_override}'
+qe_only_disable_image_policy: ${qe_only_disable_image_policy}
 enable_local_registry: ${enable_local_registry}
 fips_compliant: ${fips_compliant}
 

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -69,6 +69,7 @@ variable "openshift_install_tarball" {}
 variable "public_key" {}
 variable "pull_secret" {}
 variable "release_image_override" {}
+variable "qe_only_disable_image_policy" {}
 
 variable "private_network_mtu" {}
 

--- a/ocp.tf
+++ b/ocp.tf
@@ -153,6 +153,7 @@ module "install" {
   openshift_client_tarball       = var.openshift_client_tarball
   storage_type                   = local.storage_type
   release_image_override         = var.release_image_override
+  qe_only_disable_image_policy   = var.qe_only_disable_image_policy
   private_network_mtu            = var.private_network_mtu
   enable_local_registry          = var.enable_local_registry
   local_registry_image           = var.local_registry_image

--- a/var.tfvars
+++ b/var.tfvars
@@ -74,6 +74,8 @@ use_zone_info_for_names = true # If set it to false, the zone info would not be 
 #ocp_release_name           = "ocp-release"
 #release_image_override     = ""
 
+#qe_only_disable_image_policy = false # Set to true to disable ClusterImagePolicy for nightly builds. IBM/Red Hat QE Only: This feature puts a cluster in unsupported mode.
+
 
 #helpernode_repo            = "https://github.com/redhat-cop/ocp4-helpernode"
 #helpernode_tag             = ""

--- a/variables.tf
+++ b/variables.tf
@@ -444,6 +444,12 @@ variable "release_image_override" {
   default = ""
 }
 
+variable "qe_only_disable_image_policy" {
+  type        = bool
+  description = "IBM/Red Hat QE Only: Disables ClusterImagePolicy so Nightly builds can be deployed. This feature puts a cluster in unsupported mode."
+  default     = false
+}
+
 # Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
 variable "cluster_domain" {
   type        = string


### PR DESCRIPTION
## Summary
This PR adds the `qe_only_disable_image_policy` flag to ocp4-upi-powervs for PowerVS OCP deployments, matching the implementation in ocp4-playbooks.

## Purpose
This flag allows QE teams to disable image policy checks during OpenShift installation on PowerVS for testing purposes.


## Dependencies
- ✅ Requires ocp4-playbooks PR to be merged first: [ocp4-playbooks](https://github.com/ocp-power-automation/ocp4-playbooks/pull/204)

CC: @prb112 @sudeeshjohn 