### PR TITLE
Adding RHEL 10 Support for PowerVS

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -294,7 +294,13 @@ else
     sudo subscription-manager register --org='${var.rhel_subscription_org}' --activationkey='${var.rhel_subscription_activationkey}' --force
 fi
 sudo subscription-manager refresh
-sudo subscription-manager attach --auto
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -lt 10 ]; then
+    echo "RHEL $RHEL_VERSION detected: Attaching subscriptions..."
+    sudo subscription-manager attach --auto
+else
+    echo "RHEL $RHEL_VERSION detected: Skipping 'attach' (SCA active)."
+fi
 EOF
     ]
   }
@@ -341,11 +347,11 @@ resource "null_resource" "enable_repos" {
 if ( [[ -z "${var.rhel_subscription_username}" ]] || [[ "${var.rhel_subscription_username}" == "<subscription-id>" ]] ) && [[ -z "${var.rhel_subscription_org}" ]]; then
   sudo yum install -y epel-release
 else
-  os_ver=$(cat /etc/os-release | egrep "^VERSION_ID=" | awk -F'"' '{print $2}')
-  if [[ $os_ver != "9"* ]]; then
+  os_ver=$(grep -E '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+  if [[ $os_ver == "8" ]]; then
     sudo subscription-manager repos --enable ${var.ansible_repo_name}
   else
-    sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+    sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$${os_ver}.noarch.rpm
   fi
 fi
 EOF
@@ -382,11 +388,29 @@ resource "null_resource" "bastion_packages" {
     ]
   }
   provisioner "remote-exec" {
-    inline = [
-      "sudo yum install -y ansible",
-      "ansible-galaxy collection install community.crypto",
-      "ansible-galaxy collection install ansible.posix",
-      "ansible-galaxy collection install kubernetes.core"
+    inline = [<<EOF
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -ge 9 ]; then
+  sudo yum install -y ansible-core
+else
+  sudo yum install -y ansible
+fi
+ansible-galaxy collection install community.crypto
+ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install kubernetes.core
+EOF
+    ]
+  }
+  provisioner "remote-exec" {
+    inline = [<<EOF
+# On RHEL 10+, NetworkManager overwrites `/etc/resolv.conf`, undoing the helpernode-set `127.0.0.1` DNS - 
+# This prevents NetworkManager from managing it so the local named config persists.
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -ge 10 ]; then
+  echo -e '[main]\ndns=none' | sudo tee /etc/NetworkManager/conf.d/90-dns-none.conf > /dev/null
+  sudo systemctl reload NetworkManager
+fi
+EOF
     ]
   }
 }
@@ -425,6 +449,7 @@ resource "null_resource" "setup_nfs_disk" {
       "sudo mkfs.xfs /dev/${local.disk_config.disk_name}",
       "echo '/dev/${local.disk_config.disk_name} ${local.storage_path} xfs defaults 0 0' | sudo tee -a /etc/fstab > /dev/null",
       "sudo mount ${local.storage_path}",
+      "sudo systemctl daemon-reload",
     ]
   }
 }

--- a/modules/1_prepare/templates/create_disk_link.sh
+++ b/modules/1_prepare/templates/create_disk_link.sh
@@ -19,7 +19,7 @@ else
     echo "Disk path is /dev/mapper/mpath*"
 fi
 
-for device in $(ls -1 $disk_path|egrep -v "[0-9]$"); do
+for device in $(ls -1 $disk_path | grep -E -v "[0-9]$"); do
     if [[ ! -b $device"1" ]]; then
         # Convert disk size to GB
         device_size=$(lsblk -b -dn -o SIZE $device | awk '{print $1/1073741824}')

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -328,10 +328,19 @@ resource "null_resource" "external_services" {
   }
 
   provisioner "remote-exec" {
-    inline = [
-      "echo 'Adding static route for VPC subnet in dhcpd'",
-      "sudo sed -i '/option routers/i option static-routes ${cidrhost(var.vpc_cidr, 0)} ${var.gateway_ip};' /etc/dhcp/dhcpd.conf",
-      "sudo systemctl restart dhcpd.service"
+    inline = [<<-EOF
+echo 'Adding static route for VPC subnet in dhcpd'
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -lt 10 ]; then
+  sudo sed -i '/option routers/i option static-routes ${cidrhost(var.vpc_cidr, 0)} ${var.gateway_ip};' /etc/dhcp/dhcpd.conf
+  sudo systemctl restart dhcpd.service
+else
+  sudo cp /etc/kea/kea-dhcp4.conf /etc/kea/kea-dhcp4.conf.bak
+  sudo jq '.Dhcp4["option-data"] |= [{"name":"classless-static-route", "data":"${cidrhost(var.vpc_cidr, 0)}, ${var.gateway_ip}"}] + .' /etc/kea/kea-dhcp4.conf > /etc/kea/tmp-kea.conf
+  sudo mv /etc/kea/tmp-kea.conf /etc/kea/kea-dhcp4.conf
+  sudo systemctl restart kea-dhcp4.service
+fi
+EOF
     ]
   }
 }
@@ -355,9 +364,18 @@ resource "null_resource" "pre_install" {
 
   # DHCP config for setting MTU; Since helpernode DHCP template does not support MTU setting
   provisioner "remote-exec" {
-    inline = [
-      "sudo sed -i.mtubak '/option routers/i option interface-mtu ${var.private_network_mtu};' /etc/dhcp/dhcpd.conf",
-      "sudo systemctl restart dhcpd.service"
+    inline = [<<-EOF
+RHEL_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"' | cut -d'.' -f1)
+if [ "$RHEL_VERSION" -lt 10 ]; then
+  sudo sed -i.mtubak '/option routers/i option interface-mtu ${var.private_network_mtu};' /etc/dhcp/dhcpd.conf
+  sudo systemctl restart dhcpd.service
+else
+  sudo cp /etc/kea/kea-dhcp4.conf /etc/kea/kea-dhcp4.conf.bak
+  sudo jq '.Dhcp4["option-data"] |= [{"name":"interface-mtu","data":"${var.private_network_mtu}"}] + .' /etc/kea/kea-dhcp4.conf > /etc/kea/tmp-kea.conf
+  sudo mv /etc/kea/tmp-kea.conf /etc/kea/kea-dhcp4.conf
+  sudo systemctl restart kea-dhcp4.service
+fi
+EOF
     ]
   }
 }


### PR DESCRIPTION
Changes made for [OPENSHIFTP-754](https://jsw.ibm.com/browse/OPENSHIFTP-754): OCP Automation: Support RHEL10/CentOS10

- Adds NFS disk support changes
- Handle subscription-manager attach differences.
- Added support for kea-dhcp4
- prevent NetworkManager from overwriting resolv.conf file and fix hostname resolution issue on RHEL 10+.
- Replace deprecated `ansible` with `ansible-core`.

Verification done with RHEL10 & RHEL9 cluster deployment.

Supporting PRs merged already - 
- ocp4-helpernode: https://github.com/redhat-cop/ocp4-helpernode/pull/338
- ocp4-playbooks: https://github.com/ocp-power-automation/ocp4-playbooks/pull/207
- ocp4-upi-powervm: https://github.com/ocp-power-automation/ocp4-upi-powervm/pull/303

CC: @prb112 